### PR TITLE
Add initial pass for Idents schema

### DIFF
--- a/cncnet-api/app/Http/Controllers/ApiQuickMatchController.php
+++ b/cncnet-api/app/Http/Controllers/ApiQuickMatchController.php
@@ -28,6 +28,16 @@ class ApiQuickMatchController extends Controller
         $this->playerService = new PlayerService();
     }
 
+    public function createIdentTest(Request $request)
+    {
+        $ladder = $this->ladderService->getLadderByGame("yr");
+        $player = $this->playerService->findPlayerByUsername("neo", $ladder);
+        
+        $this->playerService->addIdent($player, "YR.664c90");
+        
+        return \App\UserIdent::where("user_id", $player->user_id)->get();
+    }
+
     public function clientVersion(Request $request, $platform = null)
     {
         return json_encode(DB::table("client_version")->where("platform", $platform)->first());

--- a/cncnet-api/app/Http/Services/PlayerService.php
+++ b/cncnet-api/app/Http/Services/PlayerService.php
@@ -2,6 +2,8 @@
 
 use JWTAuth;
 use Tymon\JWTAuth\Exceptions\JWTException;
+use App\Ident;
+use App\UserIdent;
 
 class PlayerService
 {
@@ -115,5 +117,33 @@ class PlayerService
         $playerRating->rating = $newRating;
         $playerRating->rated_games = $playerRating->rated_games + 1;
         $playerRating->save();
+    }
+
+    /**
+     * Add a players ident
+     */
+    public function addIdent($player, $identString)
+    {
+        if ($player == null) { return; }
+        
+        $ident = \App\Ident::where("ident", $identString)->first();
+        if ($ident == null)
+        {
+            $ident = new \App\Ident();
+            $ident->ident = $identString;
+            $ident->save();
+        }
+
+        $userIdent = \App\UserIdent::where("user_id", $player->user_id)
+            ->where("ident_id", $ident->id)
+            ->first();
+
+        if ($userIdent == null)
+        {
+            $userIdent = new \App\UserIdent();
+            $userIdent->user_id = $player->user_id;
+            $userIdent->ident_id = $ident->id;
+            $userIdent->save();
+        }
     }
 }

--- a/cncnet-api/app/Http/routes.php
+++ b/cncnet-api/app/Http/routes.php
@@ -111,6 +111,7 @@ Route::group(['prefix' => 'api/v1/auth/'], function()
 
 Route::group(['prefix' => 'api/v1/'], function ()
 {
+    Route::get('/tests', 'ApiQuickMatchController@createIdentTest');
     Route::get('/user/account', 'ApiUserController@getAccount');
     Route::post('/user/create', 'ApiUserController@createUser');
 

--- a/cncnet-api/app/Ident.php
+++ b/cncnet-api/app/Ident.php
@@ -1,0 +1,11 @@
+<?php namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Ident extends Model
+{
+    public function __constructor()
+    {
+
+    }
+}

--- a/cncnet-api/app/UserIdent.php
+++ b/cncnet-api/app/UserIdent.php
@@ -1,0 +1,11 @@
+<?php namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class UserIdent extends Model
+{
+    public function __constructor()
+    {
+
+    }
+}

--- a/cncnet-api/database/migrations/2019_08_03_154034_create_idents_table.php
+++ b/cncnet-api/database/migrations/2019_08_03_154034_create_idents_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateIdentsTable extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::create('idents', function(Blueprint $table)
+		{
+			$table->increments('id');
+			$table->string('ident');
+			$table->timestamps();
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::table('idents', function(Blueprint $table)
+		{
+            $table->dropColumn('ident');
+		});
+	}
+}

--- a/cncnet-api/database/migrations/2019_08_03_154232_create_user_idents_table.php
+++ b/cncnet-api/database/migrations/2019_08_03_154232_create_user_idents_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateUserIdentsTable extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::create('user_idents', function(Blueprint $table)
+		{
+            $table->string('user_id');
+			$table->string('ident_id');
+			$table->timestamps();
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::table('user_idents', function(Blueprint $table)
+		{
+            $table->dropColumn('user_id');
+            $table->dropColumn('ident_id');
+		});
+	}
+
+}


### PR DESCRIPTION
- Created a test endpoint @ `Route::get('/tests', 'ApiQuickMatchController@createIdentTest')`
- Can add an ident in QM requests using `$this->playerService->addIdent($player, "YR.664c90");`
- Idents table with all idents. UserIdents table with `user_id` & `ident_id`
