### PR TITLE
add the ability to reset a player's points via a laundry service

### DIFF
--- a/cncnet-api/app/Http/Controllers/AdminController.php
+++ b/cncnet-api/app/Http/Controllers/AdminController.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
@@ -25,11 +26,12 @@ class AdminController extends Controller
 
     public function getAdminIndex(Request $request)
     {
-        return view("admin.index", ["ladders" => $this->ladderService->getLatestLadders(),
-                                    "clan_ladders" => $this->ladderService->getLatestLadders(),
-                                    "all_ladders" => \App\Ladder::all(),
-                                    "schemas" => \App\GameObjectSchema::managedBy($request->user()),
-                                    "user" => $request->user(),
+        return view("admin.index", [
+            "ladders" => $this->ladderService->getLatestLadders(),
+            "clan_ladders" => $this->ladderService->getLatestLadders(),
+            "all_ladders" => \App\Ladder::all(),
+            "schemas" => \App\GameObjectSchema::managedBy($request->user()),
+            "user" => $request->user(),
         ]);
     }
 
@@ -49,8 +51,17 @@ class AdminController extends Controller
         $user = $request->user();
         $spawnOptions = \App\SpawnOption::all();
 
-        return view("admin.ladder-setup", compact('ladders', 'ladder', 'clan_ladders', 'objectSchemas',
-                                                  'rule', 'mapPools', 'maps', 'user', 'spawnOptions'));
+        return view("admin.ladder-setup", compact(
+            'ladders',
+            'ladder',
+            'clan_ladders',
+            'objectSchemas',
+            'rule',
+            'mapPools',
+            'maps',
+            'user',
+            'spawnOptions'
+        ));
     }
 
     public function getGameSchemaSetup(Request $request, $gameSchemaId)
@@ -81,7 +92,7 @@ class AdminController extends Controller
             return redirect()->back();
         }
 
-        $manager = \App\ObjectSchemaManager::firstOrCreate([ 'game_object_schema_id' => $gameSchema->id, 'user_id' => $user->id ]);
+        $manager = \App\ObjectSchemaManager::firstOrCreate(['game_object_schema_id' => $gameSchema->id, 'user_id' => $user->id]);
 
         $request->session()->flash('success', "Manager added");
         return redirect()->back();
@@ -171,24 +182,33 @@ class AdminController extends Controller
         if ($search && $exact)
         {
             $players = \App\Player::where("username", "=", "{$search}")->paginate(20);
-        } 
+        }
         else if ($search)
-        {          
-            $players = Cache::remember("admin/users/{$search}{$page}", 20, function () use ($search) { return \App\Player::where("username", "LIKE", "%{$search}%")->paginate(20); });
+        {
+            $players = Cache::remember("admin/users/{$search}{$page}", 20, function () use ($search)
+            {
+                return \App\Player::where("username", "LIKE", "%{$search}%")->paginate(20);
+            });
         }
 
         if ($userId)
         {
-            $users = Cache::remember("admin/users/users/{$page}", 20, function () use ($userId) { return \App\User::where("id", $userId)->paginate(20); });
+            $users = Cache::remember("admin/users/users/{$page}", 20, function () use ($userId)
+            {
+                return \App\User::where("id", $userId)->paginate(20);
+            });
         }
         else
         {
-            $users = Cache::remember("admin/users/users/{$page}", 20, function () { return \App\User::orderBy("id", "DESC")->paginate(20); });
+            $users = Cache::remember("admin/users/users/{$page}", 20, function ()
+            {
+                return \App\User::orderBy("id", "DESC")->paginate(20);
+            });
         }
 
         return view("admin.manage-users", [
             "users" => $users,
-            "players" => $players != null ? $players: [],
+            "players" => $players != null ? $players : [],
             "search" => $search,
             "userId" => $userId,
             "hostname" => $hostname
@@ -207,9 +227,9 @@ class AdminController extends Controller
         $end = $date->endOfMonth()->toDateTimeString();
 
         $history = \App\LadderHistory::where("starts", "=", $start)
-                                     ->where("ends", "=", $end)
-                                     ->where("ladder_id", "=", $ladder->id)
-                                     ->first();
+            ->where("ends", "=", $end)
+            ->where("ladder_id", "=", $ladder->id)
+            ->first();
 
         $games = \App\Game::where("ladder_history_id", "=", $history->id)->orderBy("id", "DESC")->limit(100);
         return view("admin.manage-games", ["games" => $games, "ladder" => $ladder, "history" => $history]);
@@ -507,14 +527,17 @@ class AdminController extends Controller
         $ladderService = new LadderService;
         $history = $ladderService->getActiveLadderByDate(Carbon::now()->format('m-Y'), $player->ladder->game);
 
-        return view("admin.moderate-player",
-                    [ "mod"    => $mod,
-                      "player" => $player,
-                      "user"   => $user,
-                      "bans"   => $user->bans()->orderBy('created_at', 'DESC')->get(),
-                      "ladder" => $player->ladder,
-                      "history" => $history
-                    ]);
+        return view(
+            "admin.moderate-player",
+            [
+                "mod"    => $mod,
+                "player" => $player,
+                "user"   => $user,
+                "bans"   => $user->bans()->orderBy('created_at', 'DESC')->get(),
+                "ladder" => $player->ladder,
+                "history" => $history
+            ]
+        );
     }
 
     public function getUserBan(Request $request, $ladderId = null, $playerId = null, $banType = 0)
@@ -530,22 +553,25 @@ class AdminController extends Controller
 
         $user = $player->user;
 
-        return view("admin.edit-ban",
-                    [ "mod"    => $mod,
-                      "player" => $player,
-                      "user"   => $user,
-                      "ladder" => $player->ladder,
-                      "id" => null,
-                      "expires" => null,
-                      "admin_id" => $mod->id,
-                      "user_id" => $user->id,
-                      "ban_type" => $banType,
-                      "internal_note" => "",
-                      "plubic_reason" => "",
-                      "ip_address_id" => $user->ip->id,
-                      "start_or_end" => false,
-                      "banDesc" => \App\Ban::typeToDescription($banType) ." - ". \App\Ban::banStyle($banType)
-                    ]);
+        return view(
+            "admin.edit-ban",
+            [
+                "mod"    => $mod,
+                "player" => $player,
+                "user"   => $user,
+                "ladder" => $player->ladder,
+                "id" => null,
+                "expires" => null,
+                "admin_id" => $mod->id,
+                "user_id" => $user->id,
+                "ban_type" => $banType,
+                "internal_note" => "",
+                "plubic_reason" => "",
+                "ip_address_id" => $user->ip->id,
+                "start_or_end" => false,
+                "banDesc" => \App\Ban::typeToDescription($banType) . " - " . \App\Ban::banStyle($banType)
+            ]
+        );
     }
 
     public function editUserBan(Request $request, $ladderId = null, $playerId = null, $banId = null)
@@ -565,22 +591,25 @@ class AdminController extends Controller
 
         $user = $player->user;
 
-        return view("admin.edit-ban",
-                    [ "mod"    => $mod,
-                      "player" => $player,
-                      "user"   => $user,
-                      "ladder" => $player->ladder,
-                      "id" => $ban->id,
-                      "expires" => $ban->expires->eq(\App\Ban::unstartedBanTime()) ? null : $ban->expires,
-                      "admin_id" => $mod->id,
-                      "user_id" => $user->id,
-                      "ban_type" => $ban->ban_type,
-                      "internal_note" => $ban->internal_note,
-                      "plubic_reason" => $ban->plubic_reason,
-                      "ip_address_id" => $ban->ip_address_id,
-                      "start_or_end" => false,
-                      "banDesc" => \App\Ban::typeToDescription($ban->ban_type) ." - ". \App\Ban::banStyle($ban->ban_type)
-                    ]);
+        return view(
+            "admin.edit-ban",
+            [
+                "mod"    => $mod,
+                "player" => $player,
+                "user"   => $user,
+                "ladder" => $player->ladder,
+                "id" => $ban->id,
+                "expires" => $ban->expires->eq(\App\Ban::unstartedBanTime()) ? null : $ban->expires,
+                "admin_id" => $mod->id,
+                "user_id" => $user->id,
+                "ban_type" => $ban->ban_type,
+                "internal_note" => $ban->internal_note,
+                "plubic_reason" => $ban->plubic_reason,
+                "ip_address_id" => $ban->ip_address_id,
+                "start_or_end" => false,
+                "banDesc" => \App\Ban::typeToDescription($ban->ban_type) . " - " . \App\Ban::banStyle($ban->ban_type)
+            ]
+        );
     }
 
     public function saveUserBan(Request $request, $ladderId = null, $playerId = null, $banId = null)
@@ -637,7 +666,7 @@ class AdminController extends Controller
 
         $ban->save();
 
-        $request->session()->flash('success', "Ban ". $banFlash);
+        $request->session()->flash('success', "Ban " . $banFlash);
         return redirect()->action('AdminController@getLadderPlayer', ['ladderId' => $ladderId, 'playerId' => $playerId]);
     }
 
@@ -690,6 +719,92 @@ class AdminController extends Controller
         $alert->save();
 
         $request->session()->flash('success', "Alert has been updated");
+        return redirect()->back();
+    }
+
+    /**
+     * Set all player's points for their played games to 0 of a given ladder history.
+     */
+    public function laundryService(Request $request)
+    {
+        $ladderHistoryId = $request->ladderHistory_id;
+
+        $playerId = $request->player_id;
+
+        $ladderHistory = \App\LadderHistory::find($ladderHistoryId);
+
+        if ($ladderHistory == null)
+            $request->session()->flash('error', 'Unabled to find ladder history');
+
+        $playerCache = \App\PlayerCache::where('player_id', '=', $playerId)
+            ->where('ladder_history_id', '=', $ladderHistoryId)
+            ->first();
+        if ($playerCache == null)
+            $request->session()->flash('error', 'Unabled to find player cache');
+
+        //Query for the player's game reports from the ladder history month
+        $playerGameReports = \App\PlayerGameReport::where('player_id', '=', $playerId)->where('created_at', '<', $ladderHistory->ends)->where('created_at', '>', $ladderHistory->starts)->get();
+
+        //set the players points to 0
+        foreach ($playerGameReports as $playerGameReport)
+        {
+            if ($playerGameReport->points != 0)
+            {
+                $playerGameReport->backupPts = $playerGameReport->points;
+                $playerGameReport->points = 0;
+                $playerGameReport->save();
+            }
+        }
+
+        $playerCache->points = 0;
+        $playerCache->save();
+
+        $request->session()->flash('success', "Player games have been laundered");
+        return redirect()->back();
+    }
+
+    /**
+     * Reverse Launder and restore a player's points from their games.
+     */
+    public function undoLaundryService(Request $request)
+    {
+        $ladderHistoryId = $request->ladderHistory_id;
+
+        $playerId = $request->player_id;
+
+        $ladderHistory = \App\LadderHistory::find($ladderHistoryId);
+
+        if ($ladderHistory == null)
+            $request->session()->flash('error', 'Unabled to find ladder history');
+
+        $playerCache = \App\PlayerCache::where('player_id', '=', $playerId)
+            ->where('ladder_history_id', '=', $ladderHistoryId)
+            ->first();
+
+        if ($playerCache == null)
+            $request->session()->flash('error', 'Unabled to find player cache');
+
+        $player = \App\Player::find($playerId);
+        if ($player == null)
+            $request->session()->flash('error', 'Unabled to find player');
+
+        //Query for the player's game reports from the ladder history month
+        $playerGameReports = \App\PlayerGameReport::where('player_id', '=', $playerId)->where('created_at', '<', $ladderHistory->ends)->where('created_at', '>', $ladderHistory->starts)->get();
+
+        //reset player's points from games played using backupPts
+        foreach ($playerGameReports as $playerGameReport)
+        {
+            if ($playerGameReport->backupPts != 0)
+            {
+                $playerGameReport->points = $playerGameReport->backupPts;
+                $playerGameReport->save();
+            }
+        }
+
+        $playerCache->points = $player->points($ladderHistory);
+        $playerCache->save();
+
+        $request->session()->flash('success', "Player games have been reset");
         return redirect()->back();
     }
 }

--- a/cncnet-api/app/Http/Controllers/AdminController.php
+++ b/cncnet-api/app/Http/Controllers/AdminController.php
@@ -789,7 +789,9 @@ class AdminController extends Controller
             $request->session()->flash('error', 'Unabled to find player');
 
         //Query for the player's game reports from the ladder history month
-        $playerGameReports = \App\PlayerGameReport::where('player_id', '=', $playerId)->where('created_at', '<', $ladderHistory->ends)->where('created_at', '>', $ladderHistory->starts)->get();
+        $playerGameReports = \App\PlayerGameReport::where('player_id', '=', $playerId)
+            ->where('created_at', '<', $ladderHistory->ends)
+            ->where('created_at', '>', $ladderHistory->starts)->get();
 
         //reset player's points from games played using backupPts
         foreach ($playerGameReports as $playerGameReport)
@@ -797,8 +799,9 @@ class AdminController extends Controller
             if ($playerGameReport->backupPts != 0)
             {
                 $playerGameReport->points = $playerGameReport->backupPts;
-                $playerGameReport->save();
             }
+            $playerGameReport->backupPts = 0;
+            $playerGameReport->save();
         }
 
         $playerCache->points = $player->points($ladderHistory);

--- a/cncnet-api/app/Http/Controllers/LadderController.php
+++ b/cncnet-api/app/Http/Controllers/LadderController.php
@@ -194,16 +194,21 @@ class LadderController extends Controller
             if ($ban)
                 $bans[] = $ban;
         }
+        $mod = $request->user();
+
+        $ladderPlayer = $this->ladderService->getLadderPlayer($history, $player->username);
 
         return view
         (
             "ladders.player-view",
             array
             (
+                "mod" => $mod,
                 "ladders" => $this->ladderService->getLatestLadders(),
                 "clan_ladders" => $this->ladderService->getLatestClanLadders(),
                 "history" => $history,
-                "player" => json_decode(json_encode($this->ladderService->getLadderPlayer($history, $player->username))),
+                "ladderPlayer" => json_decode(json_encode($ladderPlayer)),
+                "player" => $ladderPlayer['player'],
                 "games" => $games,
                 "userIsMod" => $userIsMod,
                 "playerUser" => $playerUser,

--- a/cncnet-api/app/Http/routes.php
+++ b/cncnet-api/app/Http/routes.php
@@ -96,6 +96,8 @@ Route::group(['prefix' => 'admin/moderate/{ladderId}', 'middleware' => 'auth', '
     Route::post('/player/{playerId}/editban/{banId}', 'AdminController@saveUserBan');
     Route::post('/player/{playerId}/editban', 'AdminController@saveUserBan');
     Route::post('/player/{playerId}/alert', 'AdminController@editPlayerAlert');
+    Route::post('/player/{playerId}/laundry', 'AdminController@laundryService');
+    Route::post('/player/{playerId}/undoLaundry', 'AdminController@undoLaundryService');
 });
 
 Route::group(['prefix' => 'account', 'middleware' => 'auth'], function ()

--- a/cncnet-api/app/Player.php
+++ b/cncnet-api/app/Player.php
@@ -329,4 +329,18 @@ class Player extends Model
     {
         return $this->hasOne('App\IrcAssociation');
     }
+
+    /**
+     * Return true if player has been laundered
+     * A player has been laundered if their player game reports have 'backupPts' which is populated when a launder occurs, and erased when launder is undone.
+     */
+    public function laundered($ladderHistory)
+    {
+        $sum = \App\PlayerGameReport::where('player_id', '=', $this->id)
+            ->where('created_at', '<', $ladderHistory->ends)
+            ->where('created_at', '>', $ladderHistory->starts)
+            ->sum('backupPts');
+
+        return $sum > 0;
+    }
 }

--- a/cncnet-api/database/migrations/2021_11_23_045941_add_old_pts_to_game_report.php
+++ b/cncnet-api/database/migrations/2021_11_23_045941_add_old_pts_to_game_report.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddOldPtsToGameReport extends Migration {
+
+	/**
+	 * Run the migrations.
+	 * If a player gets laundered and their points set to 0,
+	 * Store the backupPts values in case the launder needs to be undone.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::table('player_game_reports', function (Blueprint $table) {
+			$table->integer('backupPts')->default(0);
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::table('player_game_reports', function (Blueprint $table) {
+			$table->dropColumn('backupPts');
+		});
+	}
+
+}

--- a/cncnet-api/resources/views/admin/moderate-player.blade.php
+++ b/cncnet-api/resources/views/admin/moderate-player.blade.php
@@ -93,7 +93,7 @@
                         @endforeach
                         <option value="new">&lt;new></option>
                     </select>
-                    <button type="button" class="btn btn-primary btn-md" data-toggle="modal" data-target="#editAlert">Edit </button>
+                    <button type="button" class="btn btn-primary btn-md" data-toggle="modal" data-target="editAlert">Edit </button>
                 </div>
 
                 <div class="col-md-12">

--- a/cncnet-api/resources/views/admin/moderate-player.blade.php
+++ b/cncnet-api/resources/views/admin/moderate-player.blade.php
@@ -93,7 +93,7 @@
                         @endforeach
                         <option value="new">&lt;new></option>
                     </select>
-                    <button type="button" class="btn btn-primary btn-md" data-toggle="modal" data-target="editAlert">Edit </button>
+                    <button type="button" class="btn btn-primary btn-md" data-toggle="modal" data-target="#editAlert">Edit </button>
                 </div>
 
                 <div class="col-md-12">

--- a/cncnet-api/resources/views/ladders/player-view.blade.php
+++ b/cncnet-api/resources/views/ladders/player-view.blade.php
@@ -72,6 +72,11 @@
                                         <div class="container-fluid">
                                             <div class="row content">
                                                 <div class="col-md-12 player-box player-card list-inline">
+
+                                                    @if(!$player->laundered($history))
+                                                    <label>Are you sure you want to set all of {{$player->username}}'s points to 0?</label>
+                                                    @endif
+                                                    
                                                     <div style="display: inline-block">
                                                         <form method="POST" action="/admin/moderate/{{$player->ladder->id}}/player/{{$player->id}}/laundry">
                                                             <input type="hidden" name="_token" value="{{ csrf_token() }}">
@@ -80,6 +85,8 @@
                                                             <button type="submit" name="submit" value="update" class="btn btn-danger btn-md">Launder</button>
                                                         </form>
                                                     </div>
+
+                                                    @if($player->laundered($history))
                                                     <div style="padding-top: 5px; display: inline-block">
                                                         <form method="POST" action="/admin/moderate/{{$player->ladder->id}}/player/{{$player->id}}/undoLaundry">
                                                             <input type="hidden" name="_token" value="{{ csrf_token() }}">
@@ -88,6 +95,7 @@
                                                             <button type="submit" name="submit" value="update" class="btn btn-primary btn-sm">Undo Launder</button>
                                                         </form>
                                                     </div>
+                                                    @endif
                                                 </div>
                                             </div>
                                         </div>

--- a/cncnet-api/resources/views/ladders/player-view.blade.php
+++ b/cncnet-api/resources/views/ladders/player-view.blade.php
@@ -7,31 +7,31 @@
 
 @section('feature')
 <div class="game">
-<div class="feature-background sub-feature-background">
-    <div class="container">
-        <div class="row text-center">
-            <div class="col-md-8 col-md-offset-2">
-                <h1>
-                    {{ $history->ladder->name }}
-                </h1>
-                <p>
-                    CnCNet Ladders <strong>1vs1</strong>
-                </p>
-                <p>
-                    <a href="{{ "/ladder/". $history->short . "/" . $history->ladder->abbreviation }}" class="previous-link">
-                        <i class="fa fa-caret-left" aria-hidden="true"></i>
-                        <i class="fa fa-caret-left" aria-hidden="true"></i>
-                    </a>
-                </p>
+    <div class="feature-background sub-feature-background">
+        <div class="container">
+            <div class="row text-center">
+                <div class="col-md-8 col-md-offset-2">
+                    <h1>
+                        {{ $history->ladder->name }}
+                    </h1>
+                    <p>
+                        CnCNet Ladders <strong>1vs1</strong>
+                    </p>
+                    <p>
+                        <a href="{{ "/ladder/". $history->short . "/" . $history->ladder->abbreviation }}" class="previous-link">
+                            <i class="fa fa-caret-left" aria-hidden="true"></i>
+                            <i class="fa fa-caret-left" aria-hidden="true"></i>
+                        </a>
+                    </p>
+                </div>
             </div>
         </div>
     </div>
 </div>
-</div>
 @endsection
 
 @section('content')
-<?php $card = \App\Card::find($player->player->card_id); ?>
+<?php $card = \App\Card::find($ladderPlayer->player->card_id); ?>
 
 <div class="player">
     <div class="feature-background player-card {{ $card->short or "no-card" }}">
@@ -41,54 +41,89 @@
                 <div class="player-stats">
 
                     <h1 class="username">
-                        {{ $player->username }}
+                        {{ $ladderPlayer->username }}
                     </h1>
                     <ul class="list-inline text-uppercase">
                         <li>
-                            Points <strong> {{ $player->points }} </strong>
+                            Points <strong> {{ $ladderPlayer->points }} </strong>
                             <i class="fa fa-bolt fa-fw fa-lg"></i>
                         </li>
                         <li>
-                            Wins <strong>{{ $player->games_won }}</strong>
+                            Wins <strong>{{ $ladderPlayer->games_won }}</strong>
                             <i class="fa fa-level-up fa-fw fa-lg"></i>
                         </li>
                         @if($userIsMod)
-                            <li>
-                                <a href="/admin/moderate/{{ $ladderId }}/player/{{ $player->id }}" class="btn btn-sm btn-danger">Moderation Actions</a>
-                            </li>
+                        <li>
+                            <a href="/admin/moderate/{{ $ladderId }}/player/{{ $ladderPlayer->id }}" class="btn btn-sm btn-danger">Moderation Actions</a>
+                        </li>
+                        @endif
+
+                        @if($mod->isLadderAdmin($player['ladder']))
+                        <button type="button" class="btn btn-danger btn-sm" data-toggle="modal" data-target="#submitLaundryService">Laundry Service</button>
+
+                        <div class="modal fade" id="submitLaundryService" tabIndex="-1" role="dialog">
+                            <div class="modal-dialog modal-md" role="document">
+                                <div class="modal-content">
+                                    <div class="modal-header">
+                                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                                        <h3 class="modal-title">Submit Laundry Service</h3>
+                                    </div>
+                                    <div class="modal-body clearfix">
+                                        <div class="container-fluid">
+                                            <div class="row content">
+                                                <div class="col-md-12 player-box player-card list-inline">
+                                                    <form method="POST" action="/admin/moderate/{{$player->ladder->id}}/player/{{$player->id}}/laundry">
+                                                        <input type="hidden" name="_token" value="{{ csrf_token() }}">
+                                                        <input name="player_id" type="hidden" value="{{ $player->id }}" />
+                                                        <input name="ladderHistory_id" type="hidden" value="{{ $history->id }}" />
+                                                        <button type="submit" name="submit" value="update" class="btn btn-danger btn-md">Launder</button>
+                                                    </form>
+                                                    <form method="POST" action="/admin/moderate/{{$player->ladder->id}}/player/{{$player->id}}/undoLaundry">
+                                                        <input type="hidden" name="_token" value="{{ csrf_token() }}">
+                                                        <input name="player_id" type="hidden" value="{{ $player->id }}" />
+                                                        <input name="ladderHistory_id" type="hidden" value="{{ $history->id }}" />
+                                                        <button type="submit" name="submit" value="update" class="btn btn-primary btn-md">Undo Launder</button>
+                                                    </form>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                         @endif
                     </ul>
                 </div>
 
                 <div class="player-alerts">
                     @if(count($bans))
-                        <h3> Bans: </h3>
-                        <ul>
-                            @foreach($bans as $ban)
-                                <li>{{ $ban }}</li>
-                            @endforeach
-                        </ul>
+                    <h3> Bans: </h3>
+                    <ul>
+                        @foreach($bans as $ban)
+                        <li>{{ $ban }}</li>
+                        @endforeach
+                    </ul>
                     @endif
                     @if(count($alerts))
-                        <h3> Alerts:</h3>
-                        <ul>
-                            @foreach($alerts as $alert)
-                                <li>{!! $alert->message !!}</li>
-                            @endforeach
-                        </ul>
+                    <h3> Alerts:</h3>
+                    <ul>
+                        @foreach($alerts as $alert)
+                        <li>{!! $alert->message !!}</li>
+                        @endforeach
+                    </ul>
                     @endif
                 </div>
 
                 <div class="player-badges">
                     <h1 class="rank text-center">
                         <span class="text-uppercase">Rank</span>
-                        #{{ $player->rank == -1 ? "Unranked" : $player->rank }}
+                        #{{ $ladderPlayer->rank == -1 ? "Unranked" : $ladderPlayer->rank }}
                     </h1>
-                    <?php $badge = $player->badge; ?>
+                    <?php $badge = $ladderPlayer->badge; ?>
                     <div class="player-badge badge-2x">
                         @if (strlen($badge->badge) > 0)
                         <img src="/images/badges/{{ $badge->badge . ".png" }}">
-                        <p class="lead text-center">{{ $player->badge->type }}</p>
+                        <p class="lead text-center">{{ $ladderPlayer->badge->type }}</p>
                         @endif
                     </div>
                 </div>
@@ -100,50 +135,49 @@
             <div class="player-footer">
                 <div class="player-dials">
 
-                @include("components.dials", [
-                    "gamesCount" => $player->game_count,
-                    "averageFps" => $player->average_fps,
-                    "gamesWon" => $player->games_won,
-                    "gamesLost" => $player->games_lost,
-                    "gamesCount" => $player->game_count
-                ])
+                    @include("components.dials", [
+                    "gamesCount" => $ladderPlayer->game_count,
+                    "averageFps" => $ladderPlayer->average_fps,
+                    "gamesWon" => $ladderPlayer->games_won,
+                    "gamesLost" => $ladderPlayer->games_lost,
+                    "gamesCount" => $ladderPlayer->game_count
+                    ])
                 </div>
                 <div class="player-achievements">
                     <h3 class="title">Achievements</h3>
 
                     <div class="achievements-list">
-                        @if ($player->game_count >= 200)
+                        @if ($ladderPlayer->game_count >= 200)
                         <div class="achievement">
-                            <img src="/images/badges/achievement-games.png" style="height:50px"/>
-                            <h5 style="font-weight: bold; text-transform:uppercase; font-size: 10px;">Played <br/>200+ Games</h5>
+                            <img src="/images/badges/achievement-games.png" style="height:50px" />
+                            <h5 style="font-weight: bold; text-transform:uppercase; font-size: 10px;">Played <br />200+ Games</h5>
                         </div>
                         @endif
-                        @if ($player->game_count >= 300)
+                        @if ($ladderPlayer->game_count >= 300)
                         <div class="achievement">
-                            <img src="/images/badges/achievement-games.png" style="height:50px"/>
-                            <h5 style="font-weight: bold; text-transform:uppercase; font-size: 10px;">Played <br/>300+ Games</h5>
+                            <img src="/images/badges/achievement-games.png" style="height:50px" />
+                            <h5 style="font-weight: bold; text-transform:uppercase; font-size: 10px;">Played <br />300+ Games</h5>
                         </div>
                         @endif
 
-                        @if ($player->rank <= 10)
-                        <div class="achievement">
-                            @if ($player->rank == 1)
-                                <img src="/images/badges/achievement-rank1.png" style="height:50px"/>
-                                <h5 class="gold">Rank #1 Player</h5>
-                            @elseif($player->rank > 1 && $player->rank <=5)
-                                <img src="/images/badges/achievement-top5.png" style="height:50px"/>
-                                <h5 class="silver">Top 5 Player</h5>
-                            @elseif($player->rank > 5 && $player->rank <=10)
-                                <img src="/images/badges/achievement-top10.png" style="height:50px"/>
-                                <h5 class="bronze">Top 10 Player</h5>
+                        @if ($ladderPlayer->rank <= 10) <div class="achievement">
+                            @if ($ladderPlayer->rank == 1)
+                            <img src="/images/badges/achievement-rank1.png" style="height:50px" />
+                            <h5 class="gold">Rank #1 Player</h5>
+                            @elseif($ladderPlayer->rank > 1 && $ladderPlayer->rank
+                            <=5) <img src="/images/badges/achievement-top5.png" style="height:50px" />
+                            <h5 class="silver">Top 5 Player</h5>
+                            @elseif($ladderPlayer->rank > 5 && $ladderPlayer->rank
+                            <=10) <img src="/images/badges/achievement-top10.png" style="height:50px" />
+                            <h5 class="bronze">Top 10 Player</h5>
                             @endif
-                        </div>
-                        @endif
                     </div>
+                    @endif
                 </div>
             </div>
         </div>
     </div>
+</div>
 </div>
 
 
@@ -156,15 +190,15 @@
 
                     <div class="row">
                         <div class="col-md-12 text-center">
-                        {!! $games->render() !!}
+                            {!! $games->render() !!}
                         </div>
                     </div>
 
-                    @include("components.player-recent-games", ["player" => $player, "games" => $games])
+                    @include("components.player-recent-games", ["player" => $ladderPlayer, "games" => $games])
 
                     <div class="row">
                         <div class="col-md-12 text-center">
-                        {!! $games->render() !!}
+                            {!! $games->render() !!}
                         </div>
                     </div>
                 </div>

--- a/cncnet-api/resources/views/ladders/player-view.blade.php
+++ b/cncnet-api/resources/views/ladders/player-view.blade.php
@@ -72,18 +72,22 @@
                                         <div class="container-fluid">
                                             <div class="row content">
                                                 <div class="col-md-12 player-box player-card list-inline">
-                                                    <form method="POST" action="/admin/moderate/{{$player->ladder->id}}/player/{{$player->id}}/laundry">
-                                                        <input type="hidden" name="_token" value="{{ csrf_token() }}">
-                                                        <input name="player_id" type="hidden" value="{{ $player->id }}" />
-                                                        <input name="ladderHistory_id" type="hidden" value="{{ $history->id }}" />
-                                                        <button type="submit" name="submit" value="update" class="btn btn-danger btn-md">Launder</button>
-                                                    </form>
-                                                    <form method="POST" action="/admin/moderate/{{$player->ladder->id}}/player/{{$player->id}}/undoLaundry">
-                                                        <input type="hidden" name="_token" value="{{ csrf_token() }}">
-                                                        <input name="player_id" type="hidden" value="{{ $player->id }}" />
-                                                        <input name="ladderHistory_id" type="hidden" value="{{ $history->id }}" />
-                                                        <button type="submit" name="submit" value="update" class="btn btn-primary btn-md">Undo Launder</button>
-                                                    </form>
+                                                    <div style="display: inline-block">
+                                                        <form method="POST" action="/admin/moderate/{{$player->ladder->id}}/player/{{$player->id}}/laundry">
+                                                            <input type="hidden" name="_token" value="{{ csrf_token() }}">
+                                                            <input name="player_id" type="hidden" value="{{ $player->id }}" />
+                                                            <input name="ladderHistory_id" type="hidden" value="{{ $history->id }}" />
+                                                            <button type="submit" name="submit" value="update" class="btn btn-danger btn-md">Launder</button>
+                                                        </form>
+                                                    </div>
+                                                    <div style="padding-top: 5px; display: inline-block">
+                                                        <form method="POST" action="/admin/moderate/{{$player->ladder->id}}/player/{{$player->id}}/undoLaundry">
+                                                            <input type="hidden" name="_token" value="{{ csrf_token() }}">
+                                                            <input name="player_id" type="hidden" value="{{ $player->id }}" />
+                                                            <input name="ladderHistory_id" type="hidden" value="{{ $history->id }}" />
+                                                            <button type="submit" name="submit" value="update" class="btn btn-primary btn-sm">Undo Launder</button>
+                                                        </form>
+                                                    </div>
                                                 </div>
                                             </div>
                                         </div>


### PR DESCRIPTION
A button called "Laundry Service" added to the player view available only to admins. When clicked two options are available, Launder or undo laundry service.
Launder will set the player's points to a backUpPts column and set the player's points to 0.
Undo launder will set the player's points to the backUpPts column. Undo launder button is only available if the player has been laundered
New column 'backupPts' added to table 'player_game_reports'