### PR TITLE
prevent potential null maps from crashing match finder

### DIFF
--- a/cncnet-api/app/Commands/FindOpponent.php
+++ b/cncnet-api/app/Commands/FindOpponent.php
@@ -195,13 +195,18 @@ class FindOpponent extends Command implements SelfHandling, ShouldBeQueued
             {
                 $playerGameReports = $player->playerGames()
                     ->where("ladder_history_id", "=", $history->id)
+                    ->where("disconnected", "=", 0)
+                    ->where("no_completion", "=", 0)
+                    ->where("draw", "=", 0)
                     ->orderBy('created_at', 'DESC')
                     ->limit($reduceMapRepeats)
                     ->get();
 
-                $recentMaps = $playerGameReports->map(function ($item)
-                {
+                $recentMaps = $playerGameReports->map(function ($item) {
                     return $item->game->map;
+                });
+                $recentMaps = $recentMaps->filter(function ($value) {
+                    return !is_null($value);
                 });
 
                 foreach ($recentMaps as $recentMap)
@@ -214,13 +219,18 @@ class FindOpponent extends Command implements SelfHandling, ShouldBeQueued
                     $oppPlayer = $qOpn->qmPlayer->player;
                     $oppPlayerGames = $oppPlayer->playerGames()
                         ->where("ladder_history_id", "=", $history->id)
+                        ->where("disconnected", "=", 0)
+                        ->where("no_completion", "=", 0)
+                        ->where("draw", "=", 0)
                         ->orderBy('created_at', 'DESC')
                         ->limit($reduceMapRepeats)
                         ->get();
 
-                    $recentMaps = $oppPlayerGames->map(function ($item)
-                    {
+                    $recentMaps = $oppPlayerGames->map(function ($item) {
                         return $item->game->map;
+                    });
+                    $recentMaps = $recentMaps->filter(function ($value) {
+                        return !is_null($value);
                     });
 
                     foreach ($recentMaps as $recentMap) //remove the recent maps from common_qm_maps


### PR DESCRIPTION
Bug fix for 854 instances of error from 12/15/2021 error log:

```
[2021-12-15 16:55:27] staging.ERROR: exception 'ErrorException' with message 'Trying to get property of non-object' in /home/cncnet/staging/app/Commands/FindOpponent.php:335
Stack trace:
```