### PR TITLE
fix ladder showing wrong faction, pass ladder game not abbreviation

### DIFF
--- a/cncnet-api/resources/views/components/game-box.blade.php
+++ b/cncnet-api/resources/views/components/game-box.blade.php
@@ -18,7 +18,7 @@
             @foreach($gamePlayers->get() as $k => $pgr)
             <?php $gameStats = $pgr->stats; ?>
                 @if ($gameStats != null)
-                    <div class="recent-games-faction hidden-xs faction faction-{{ $gameStats->faction($history->ladder->abbreviation, $gameStats->cty) }} 
+                    <div class="recent-games-faction hidden-xs faction faction-{{ $gameStats->faction($history->ladder->game, $gameStats->cty) }} 
                         @if($k&1) faction-right @else faction-left @endif"></div>
                 @endif
             @endforeach

--- a/cncnet-api/resources/views/ladders/game-view.blade.php
+++ b/cncnet-api/resources/views/ladders/game-view.blade.php
@@ -57,7 +57,7 @@
 
                         <?php $gameStats = $pgr->stats; ?>
                         @if ($gameStats != null)
-                            <div class="hidden-xs faction faction-{{ $gameStats->faction($history->ladder->abbreviation, $gameStats->cty) }} @if($k&1) faction-right @else faction-left @endif"></div>
+                            <div class="hidden-xs faction faction-{{ $gameStats->faction($history->ladder->game, $gameStats->cty) }} @if($k&1) faction-right @else faction-left @endif"></div>
                         @endif
 
                         <?php $player = $pgr->player()->first(); ?>

--- a/cncnet-api/resources/views/ladders/listing.blade.php
+++ b/cncnet-api/resources/views/ladders/listing.blade.php
@@ -210,7 +210,7 @@
                                 $countryName = "";
                                 $side = null;
 
-                                if ( $history->ladder->abbreviation == "yr")
+                                if ( $history->ladder->game == "yr")
                                 {
                                     $side = \App\Side::where("local_id", $player->country)
                                     ->where("ladder_id", $history->ladder->id)
@@ -245,7 +245,7 @@
                                     "playerCard" => $player->card !== null ? (array_key_exists($player->card, $cards) ? $cards[$player->card + 0] : "") : "",
                                     "side" => $countryName,
                                     "url" => "/ladder/". $history->short . "/" . $history->ladder->abbreviation . "/player/" . $player->player_name,
-                                    "game" => $history->ladder->abbreviation
+                                    "game" => $history->ladder->game
                                 ])
                             </div>
                         @endforeach


### PR DESCRIPTION
Current: (Bug)
<img src="https://user-images.githubusercontent.com/11843268/166971913-17edbd6c-c0fe-46b1-98b1-6463a629f13a.png" width="252">

Fixed:
<img src="https://user-images.githubusercontent.com/11843268/166971938-f28ffb3f-39ad-439e-9465-78f88b762900.png" width="252">




