### PR TITLE
feature/map free veto

### DIFF
--- a/cncnet-api/database/migrations/2022_05_11_190356_addFreeVetoColumn.php
+++ b/cncnet-api/database/migrations/2022_05_11_190356_addFreeVetoColumn.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddFreeVetoColumn extends Migration
+{
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::table('qm_maps', function (Blueprint $table)
+		{
+			$table->integer("free_veto")
+				->nullable()
+				->default(0);
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::table('qm_maps', function (Blueprint $table)
+		{
+			$table->dropColumn("free_veto");
+		});
+	}
+}

--- a/cncnet-api/resources/views/components/game-box.blade.php
+++ b/cncnet-api/resources/views/components/game-box.blade.php
@@ -18,7 +18,7 @@
             @foreach($gamePlayers->get() as $k => $pgr)
             <?php $gameStats = $pgr->stats; ?>
                 @if ($gameStats != null)
-                    <div class="recent-games-faction hidden-xs faction faction-{{ $gameStats->faction($history->ladder->abbreviation, $gameStats->cty) }} 
+                    <div class="recent-games-faction hidden-xs faction faction-{{ $gameStats->faction($history->ladder->game, $gameStats->cty) }} 
                         @if($k&1) faction-right @else faction-left @endif"></div>
                 @endif
             @endforeach

--- a/cncnet-api/resources/views/ladders/game-view.blade.php
+++ b/cncnet-api/resources/views/ladders/game-view.blade.php
@@ -57,7 +57,7 @@
 
                         <?php $gameStats = $pgr->stats; ?>
                         @if ($gameStats != null)
-                            <div class="hidden-xs faction faction-{{ $gameStats->faction($history->ladder->abbreviation, $gameStats->cty) }} @if($k&1) faction-right @else faction-left @endif"></div>
+                            <div class="hidden-xs faction faction-{{ $gameStats->faction($history->ladder->game, $gameStats->cty) }} @if($k&1) faction-right @else faction-left @endif"></div>
                         @endif
 
                         <?php $player = $pgr->player()->first(); ?>

--- a/cncnet-api/resources/views/ladders/listing.blade.php
+++ b/cncnet-api/resources/views/ladders/listing.blade.php
@@ -210,7 +210,7 @@
                                 $countryName = "";
                                 $side = null;
 
-                                if ( $history->ladder->abbreviation == "yr")
+                                if ( $history->ladder->game == "yr")
                                 {
                                     $side = \App\Side::where("local_id", $player->country)
                                     ->where("ladder_id", $history->ladder->id)
@@ -245,7 +245,7 @@
                                     "playerCard" => $player->card !== null ? (array_key_exists($player->card, $cards) ? $cards[$player->card + 0] : "") : "",
                                     "side" => $countryName,
                                     "url" => "/ladder/". $history->short . "/" . $history->ladder->abbreviation . "/player/" . $player->player_name,
-                                    "game" => $history->ladder->abbreviation
+                                    "game" => $history->ladder->game
                                 ])
                             </div>
                         @endforeach


### PR DESCRIPTION
QmMaps now have an attribute that lets QM client know that the map can be vetoed by the player without using one of their vetoes. 

This is requested by RA2 Ladder which wants a set of QM maps that require a veto to reject, and another set of QM maps that can be rejected for "free".