### PR TITLE
Feature/map free veto

### DIFF
--- a/cncnet-api/database/migrations/2022_05_11_193609_addFreeVetoColumn.php
+++ b/cncnet-api/database/migrations/2022_05_11_193609_addFreeVetoColumn.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddFreeVetoColumn extends Migration
+{
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::table('qm_maps', function (Blueprint $table)
+		{
+			$table->integer("free_veto")
+				->nullable()
+				->default(0);
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::table('qm_maps', function (Blueprint $table)
+		{
+			$table->dropColumn("free_veto");
+		});
+	}
+}


### PR DESCRIPTION
QmMaps now have an attribute that lets QM client know that the map can be vetoed by the player without using one of their vetoes.

This is requested by RA2 Ladder which wants a set of QM maps that require a veto to reject, and another set of QM maps that can be rejected for "free".