### PR TITLE
initialize a nick name for every ladder if no nick exists

### DIFF
--- a/cncnet-api/app/Http/Controllers/ApiUserController.php
+++ b/cncnet-api/app/Http/Controllers/ApiUserController.php
@@ -31,7 +31,7 @@ class ApiUserController extends Controller
         foreach (\App\Ladder::all() as $ladder)
         {
             $players = $user->usernames()->where('ladder_id', '=', $ladder->id)->get();
-            
+
             if ($players->count() < 1)
             {
                 // Auto-register a player for each ladder if there isn't already a player registered for this user
@@ -112,6 +112,7 @@ class ApiUserController extends Controller
 
         $ladderHistory = \App\LadderHistory::where("starts", "=", $start)
             ->where("ends", "=", $end)
+            ->where('ladder_id', '=', $ladderId)
             ->first();
 
         // Detect if the player is active in the this months ladder already
@@ -130,11 +131,8 @@ class ApiUserController extends Controller
             return $tempNick;
         }
 
-        $limitLatestNickByDate = Carbon::create("2019", "09", "01");
-
         // Get nick last created limited by this new 1 nick rule
         $tempNick = \App\Player::where("user_id", $userId)
-            ->where("created_at", "<=", $limitLatestNickByDate)
             ->where('ladder_id', $ladderId)
             ->orderBy("id", "desc")
             ->first();

--- a/cncnet-api/app/Http/Controllers/ApiUserController.php
+++ b/cncnet-api/app/Http/Controllers/ApiUserController.php
@@ -63,7 +63,7 @@ class ApiUserController extends Controller
         $startOfMonth = $date->startOfMonth()->toDateTimeString();
         $endOfMonth = $date->endOfMonth()->toDateTimeString();
 
-        $activeHandles = PlayerActiveHandle::getUserActiveHandles($user->id, $startOfMonth, $endOfMonth);
+        $activeHandles = PlayerActiveHandle::getUserActiveHandles($user->id, $startOfMonth, $endOfMonth)->get();
 
         $players = [];
         foreach($activeHandles as $activeHandle)

--- a/cncnet-api/app/Http/Controllers/v2/ApiUserController.php
+++ b/cncnet-api/app/Http/Controllers/v2/ApiUserController.php
@@ -65,7 +65,7 @@ class ApiUserController extends Controller
         $startOfMonth = $date->startOfMonth()->toDateTimeString();
         $endOfMonth = $date->endOfMonth()->toDateTimeString();
 
-        $activeHandles = PlayerActiveHandle::getUserActiveHandles($user->id, $startOfMonth, $endOfMonth);
+        $activeHandles = PlayerActiveHandle::getUserActiveHandles($user->id, $startOfMonth, $endOfMonth)->get();
 
         $players = [];
         foreach ($activeHandles as $activeHandle)

--- a/cncnet-api/app/PlayerActiveHandle.php
+++ b/cncnet-api/app/PlayerActiveHandle.php
@@ -69,6 +69,34 @@ class PlayerActiveHandle extends Model
         return $hasActiveHandles;
     }
 
+    /**
+     * Return how many games played the user has played this month from their active handles.
+     */
+    public static function getUserActiveHandleGamesPlayedCount(
+        $userId,
+        $ladderId,
+        $dateStart,
+        $dateEnd
+    )
+    {
+        $activeHandles = PlayerActiveHandle::where("ladder_id", $ladderId)
+            ->where("user_id", $userId)
+            ->where("created_at", ">=", $dateStart)
+            ->where("created_at", "<=", $dateEnd)
+            ->get();
+
+        $count = 0;
+        foreach ($activeHandles as $activeHandle)
+        {
+            $count += $activeHandle->player->playerGameReports()
+                ->where('created_at', '<=', $dateEnd)
+                ->where('created_at', '>', $dateStart)
+                ->get()->count();
+        }
+
+        return $count;
+    }
+
     public function user()
     {
         $this->belongsTo('App\User');

--- a/cncnet-api/app/PlayerActiveHandle.php
+++ b/cncnet-api/app/PlayerActiveHandle.php
@@ -22,14 +22,10 @@ class PlayerActiveHandle extends Model
         return $activeHandle;
     }
 
-    public static function getPlayerActiveHandles($playerId, $ladderId, $dateStart, $dateEnd)
+    public static function getPlayerActiveHandles($playerId, $ladderId)
     {
         $activeHandles = PlayerActiveHandle::where("player_id", $playerId)
-            ->where("ladder_id", $ladderId)
-            ->where("created_at", ">=", $dateStart)
-            ->where("created_at", "<=", $dateEnd)
-            ->orderBy('created_at', 'DESC')
-            ->get();
+            ->where("ladder_id", $ladderId);
 
         return $activeHandles;
     }
@@ -51,8 +47,7 @@ class PlayerActiveHandle extends Model
         $hasActiveHandles = PlayerActiveHandle::where("user_id", $userId)
             ->where("created_at", ">=", $dateStart)
             ->where("created_at", "<=", $dateEnd)
-            ->orderBy('created_at', 'DESC')
-            ->get();
+            ->orderBy('created_at', 'DESC');
 
         return $hasActiveHandles;
     }


### PR DESCRIPTION
- Small code adjustment in player nick name creation to ensure that a nick name is created for every ladder. #80 
- Additionally, allow the user to change their player nickname this month if they have not played any games on the given ladder yet for the given month.

Tested locally with a new user, also tested with existing user.