### PR TITLE
don't create nick for private ladder

### DIFF
--- a/cncnet-api/app/Http/Controllers/ApiUserController.php
+++ b/cncnet-api/app/Http/Controllers/ApiUserController.php
@@ -89,7 +89,7 @@ class ApiUserController extends Controller
     private function getTempNicks($userId)
     {
         $tempNicks = [];
-        foreach (\App\Ladder::all() as $ladder)
+        foreach (\App\Ladder::where('private', '=', '0')->get() as $ladder) //don't create nick for private ladder
         {
             $tempNick = $this->getTempNickByLadderType($ladder->id, $userId);
             if ($tempNick != null)


### PR DESCRIPTION
the initial nick creation was creating nicks for private ladders, which was creating an issue for players who do not have access to private ladders.

![image](https://user-images.githubusercontent.com/11843268/189557873-1593525e-276d-461b-8fc6-36ce45c6b853.png)
