### PR TITLE
Potential fix for recent games box showing wrong faction

### DIFF
--- a/cncnet-api/.bladeformatterrc.json
+++ b/cncnet-api/.bladeformatterrc.json
@@ -1,0 +1,9 @@
+{
+    "indentSize": 4,
+    "wrapAttributes": "auto",
+    "wrapLineLength": 200,
+    "endWithNewLine": true,
+    "noMultipleEmptyLines": false,
+    "useTabs": false,
+    "sortHtmlAttributes": "none"
+}

--- a/cncnet-api/resources/views/components/game-box.blade.php
+++ b/cncnet-api/resources/views/components/game-box.blade.php
@@ -1,48 +1,68 @@
 <div class="game-box">
-    <div class="preview" style="background-image:url(/images/maps/{{ $game }}/{{ $map or ""}}.png)">
-        <a href="{{ $url or ""}}" class="status status-{{ $status }}"></a>
+    <div class="preview" style="background-image:url(/images/maps/{{ $game }}/{{ $map or '' }}.png)">
+        <a href="{{ $url or '' }}" class="status status-{{ $status }}"></a>
     </div>
 
-    <a href="{{ $url or ""}}" class="game-box-link" data-toggle="tooltip" data-placement="top" title="View game">
+    <a href="{{ $url or '' }}" class="game-box-link" data-toggle="tooltip" data-placement="top" title="View game">
         <div class="details text-center">
             <h4 class="title">{{ $title }}</h4>
-            <small class="status text-capitalize">{{ $status . " " . $date->diffForHumans() }}</small>
+            <small class="status text-capitalize">{{ $status . ' ' . $date->diffForHumans() }}</small>
 
-            @if($gameReport !== null)
-            <div><small class="status text-capitalize"><strong>Duration:</strong> {{ gmdate("H:i:s", $gameReport->duration) }}</small></div>
-            <div><small class="status text-capitalize"><strong>Average FPS:</strong> {{ $gameReport->fps }}</small></div>
+            @if ($gameReport !== null)
+                <div>
+                    <small class="status text-capitalize">
+                        <strong>Duration:</strong>
+                        {{ gmdate('H:i:s', $gameReport->duration) }}
+                    </small>
+                </div>
+                <div>
+                    <small class="status text-capitalize"><strong>Average FPS:</strong> {{ $gameReport->fps }}</small>
+                </div>
             @endif
         </div>
+
         @if ($points != null)
-        <div class="footer text-center {{ $history->ladder->abbreviation }}">
-            @foreach($gamePlayers->get() as $k => $pgr)
-            <?php $gameStats = $pgr->stats; ?>
-                
-                @if ($gameStats != null)
-                    @if ($history->ladder->abbreviation != "ts" && $history->ladder->abbreviation != "ra")
-                    <div class="recent-games-faction hidden-xs @if($k&1) faction-right @else faction-left @endif">
-                        <div class="player-faction player-faction-{{ \App\Stats2::getCountryById($gameStats->cty) }} @if($k&1) faction-right @else faction-left @endif">
-                        </div>
-                    </div>
-                    @else
-                        <div class="recent-games-faction hidden-xs faction faction-{{ $gameStats->faction($history->ladder->game, $gameStats->cty) }} 
-                            @if($k&1) faction-right @else faction-left @endif">
-                        </div>
-                    @endif
-                @endif
-            @endforeach
+            <div class="footer text-center {{ $history->ladder->abbreviation }}">
+                @foreach ($gamePlayers->get() as $k => $pgr)
+                    <?php $gameStats = $pgr->stats; ?>
 
-            <?php $opponent = $gamePlayers->where("player_id", "!=", $points->player_id)->first(); ?>
-            <h5 class="player {{ $status or "lost"}}">
-                {{ $points->player->username }} <span class="points">@if($points->points >= 0) +@endif{{ $points->points }}</span>
-            </h5>
-            <p class="vs">vs</p>
-            @if ($opponent)
-            <h5 class="player {{ $opponent->won ? "won" : "lost " }}">
-                {{ $opponent->player->username }} <span class="points">@if($opponent->points >= 0) +@endif{{ $opponent->points }}</span>
-            </h5>
-            @endif
-        </div>
+                    @if ($gameStats != null)
+                        @if ($history->ladder->abbreviation != 'ts' && $history->ladder->abbreviation != 'ra')
+                            @php $faction = \App\Stats2::getCountryById($pgr->stats->cty); @endphp
+                            <div class="recent-games-faction hidden-xs @if ($k & 1) faction-right @else faction-left @endif">
+                                <div class="player-faction player-faction-{{ $faction }} @if ($k & 1) faction-right @else faction-left @endif">
+                                </div>
+                            </div>
+                        @else
+                            <div
+                                class="recent-games-faction hidden-xs faction faction-{{ $faction }} 
+                            @if ($k & 1) faction-right @else faction-left @endif">
+                            </div>
+                        @endif
+                    @endif
+                @endforeach
+
+                <?php $opponent = $gamePlayers->where('player_id', '!=', $points->player_id)->first(); ?>
+
+                <h5 class="player {{ $status or 'lost' }}">
+                    {{ $points->player->username }} <span class="points">
+                        @if ($points->points >= 0)
+                            +
+                        @endif{{ $points->points }}
+                    </span>
+                </h5>
+
+                <p class="vs">vs</p>
+                @if ($opponent)
+                    <h5 class="player {{ $opponent->won ? 'won' : 'lost ' }}">
+                        {{ $opponent->player->username }} <span class="points">
+                            @if ($opponent->points >= 0)
+                                +
+                            @endif{{ $opponent->points }}
+                        </span>
+                    </h5>
+                @endif
+            </div>
         @endif
     </a>
 </div>


### PR DESCRIPTION
Potentially fixes https://github.com/CnCNet/cncnet-ladder-api/issues/100

Code change without all the formatting is `@php $faction = \App\Stats2::getCountryById($pgr->stats->cty); @endphp`
Should grab the cty from the players game report stats directly