### PR TITLE
ladder client migration

### DIFF
--- a/cncnet-api/app/Http/Controllers/v2/ApiLadderController.php
+++ b/cncnet-api/app/Http/Controllers/v2/ApiLadderController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers\v2;
+
+use Illuminate\Http\Request;
+use \App\Http\Services\LadderService;
+use \App\Http\Services\GameService;
+use \App\Http\Services\PlayerService;
+use \App\Http\Services\AuthService;
+
+class ApiLadderController extends Controller
+{
+    private $ladderService;
+
+    public function __construct()
+    {
+        $this->ladderService = new LadderService();
+    }
+
+    public function pingLadder(Request $request)
+    {
+        return "pong";
+    }
+
+    public function getLadder(Request $request, $game = null)
+    {
+        return $this->ladderService->getLadderByGameAbbreviation($game);
+    }
+
+    public function getAllLadders(Request $request)
+    {
+        return $this->ladderService->getAllNonMigratedLadders();
+    }
+
+    public function getCurrentLadders(Request $request)
+    {
+        return $this->ladderService->getLadders(false);
+    }
+
+    public function getLadderGame(Request $request, $game = null, $gameId = null)
+    {
+        return $this->ladderService->getLadderGameById($game, $gameId);
+    }
+}

--- a/cncnet-api/app/Http/Services/LadderService.php
+++ b/cncnet-api/app/Http/Services/LadderService.php
@@ -38,6 +38,30 @@ class LadderService
         return $ladders;
     }
 
+    /**
+     * Only return ladders that have not migrated to new client. Legacy QM client can pull ladders not yet migrated.
+     */
+    public function getAllNonMigratedLadders()
+    {
+        $ladders = \App\Ladder::where('is_migrated_to_new_client', 0)->get();
+
+        foreach ($ladders as $ladder)
+        {
+            $ladder["sides"] = $ladder->sides()->get();
+            $rules = $ladder->qmLadderRules;
+
+            if ($rules !== null)
+            {
+                $ladder["vetoes"] = $rules->map_vetoes;
+                $ladder["allowed_sides"] = array_map('intval', explode(',', $rules->allowed_sides));
+            }
+            $current = $this->getActiveLadderByDate(Carbon::now()->format('m-Y'), $ladder->abbreviation);
+            if ($current !== null)
+                $ladder["current"] = $current->short;
+        }
+        return $ladders;
+    }
+
     public function getLadders($private = false)
     {
         $ladders = \App\Ladder::where('private', '=', $private)->get();

--- a/cncnet-api/app/Http/routes.php
+++ b/cncnet-api/app/Http/routes.php
@@ -169,6 +169,12 @@ Route::group(['prefix' => 'api/v1/', 'middleware' => 'cache.short.public'], func
 });
 
 // Ladder Endpoints
+Route::group(['prefix' => 'api/v2/ladder', 'middleware' => 'cache.long.public'], function ()
+{
+    Route::get('/', 'ApiLadderController@getAllLadders');
+});
+
+// Ladder Endpoints
 Route::group(['prefix' => 'api/v1/ladder', 'middleware' => 'cache.long.public'], function ()
 {
     Route::get('/', 'ApiLadderController@getAllLadders');

--- a/cncnet-api/database/migrations/2022_11_04_231841_LadderColumnForNewApi.php
+++ b/cncnet-api/database/migrations/2022_11_04_231841_LadderColumnForNewApi.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class LadderColumnForNewApi extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table("ladders", function (Blueprint $table)
+        {
+            $table->tinyInteger("is_migrated_to_new_client")->default(0);
+        });
+
+        //migrate all ladders living inside of YR client
+        $migrate_ladders = ['yr', 'ra2', 'sfj', 'blitz', 'ra2-test', 'yr-test'];
+
+        foreach ($migrate_ladders as $abbreviation)
+        {
+            $ladder = \App\Ladder::where('abbreviation', $abbreviation)->first();
+            $ladder->is_migrated_to_new_client = 1;
+            $ladder->save();
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}


### PR DESCRIPTION
- Add a column to ladders to note if the ladder is available on all clients or only new client. Will prevent deprecated qm client from  interacting with ladder post ladder client migration