### PR TITLE
restrict no pt filter use based on rank

### DIFF
--- a/cncnet-api/app/Commands/FindOpponent.php
+++ b/cncnet-api/app/Commands/FindOpponent.php
@@ -139,7 +139,27 @@ class FindOpponent extends Command implements ShouldQueue
             $oppPlayer = $opponentEntry->qmPlayer->player;
             $oppUserSettings = $oppPlayer->user->userSettings; //opponent's point filter flag
 
+            $ptFilterOff = false;
+
             if ($userSettings->disabledPointFilter && $oppUserSettings->disabledPointFilter)
+            {
+                $playerRank = $player->rank($history);
+
+                $oppPlayerRank = $oppPlayer->rank($history);
+
+                //do both players' rank meet the minimum rank required for no pt filter to apply
+                if ($playerRank < $ladder_rules->point_filter_rank_threshold && $oppPlayerRank < $ladder_rules->point_filter_rank_threshold)
+                {
+                    Log::info("FindOpponent ** Players meet the min pt filter rank p1: " . $playerRank . ", p2: " . $oppPlayerRank);
+                    $ptFilterOff = true;
+                } else 
+                {
+                    Log::info("FindOpponent ** Players do not meet the min pt filter rank. p1: " . $playerRank . ", p2: " . $oppPlayerRank);
+                }
+                   
+            }
+
+            if ($ptFilterOff)
             {
                 // both players have the point filter disabled, we will ignore the point filter
                 $opponentEntriesFiltered->add($opponentEntry);

--- a/cncnet-api/app/Commands/FindOpponent.php
+++ b/cncnet-api/app/Commands/FindOpponent.php
@@ -148,7 +148,7 @@ class FindOpponent extends Command implements ShouldQueue
                 $oppPlayerRank = $oppPlayer->rank($history);
 
                 //do both players' rank meet the minimum rank required for no pt filter to apply
-                if ($playerRank < $ladder_rules->point_filter_rank_threshold && $oppPlayerRank < $ladder_rules->point_filter_rank_threshold)
+                if ($playerRank <= $ladder_rules->point_filter_rank_threshold && $oppPlayerRank <= $ladder_rules->point_filter_rank_threshold)
                 {
                     Log::info("FindOpponent ** Players meet the min pt filter rank p1: " . $playerRank . ", p2: " . $oppPlayerRank);
                     $ptFilterOff = true;

--- a/cncnet-api/app/Http/Services/AdminService.php
+++ b/cncnet-api/app/Http/Services/AdminService.php
@@ -53,6 +53,7 @@ class AdminService
         $ladderRule->all_sides = $request->all_sides;
         $ladderRule->allowed_sides = implode(",", $request->allowed_sides);
         $ladderRule->reduce_map_repeats = $request->reduce_map_repeats;
+        $ladderRule->point_filter_rank_threshold = $request->point_filter_rank_threshold;
         $ladderRule->ladder_rules_message = $request->ladder_rules_message;
         $ladderRule->ladder_discord = $request->ladder_discord;
         $ladderRule->save();

--- a/cncnet-api/database/migrations/2022_12_29_152526_LadderRulesPtFilterThreshold.php
+++ b/cncnet-api/database/migrations/2022_12_29_152526_LadderRulesPtFilterThreshold.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class LadderRulesPtFilterThreshold extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('qm_ladder_rules', function(Blueprint $table)
+		{
+            $table->integer('point_filter_rank_threshold')->default(50); //QM player must be at least this rank for 'disable pt filter' to be applied
+		});
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/cncnet-api/database/migrations/2022_12_29_152526_LadderRulesPtFilterThreshold.php
+++ b/cncnet-api/database/migrations/2022_12_29_152526_LadderRulesPtFilterThreshold.php
@@ -12,10 +12,10 @@ class LadderRulesPtFilterThreshold extends Migration
      */
     public function up()
     {
-        Schema::table('qm_ladder_rules', function(Blueprint $table)
-		{
+        Schema::table('qm_ladder_rules', function (Blueprint $table)
+        {
             $table->integer('point_filter_rank_threshold')->default(50); //QM player must be at least this rank for 'disable pt filter' to be applied
-		});
+        });
     }
 
     /**

--- a/cncnet-api/resources/views/admin/ladder-setup.blade.php
+++ b/cncnet-api/resources/views/admin/ladder-setup.blade.php
@@ -376,7 +376,7 @@
                                                 </div>
 
                                                 <div class="form-group">
-                                                    <label for="{{ $rule->ladder_id }}_point_filter_rank_threshold">Min Rank for Pt Filter</label>
+                                                    <label for="{{ $rule->ladder_id }}_point_filter_rank_threshold">Min Rank for Pt Filter to be Disabled</label>
                                                     <input id="{{ $rule->ladder_id }}_point_filter_rank_threshold" min="0" type="number" name="point_filter_rank_threshold" class="form-control"
                                                         value="{{ $rule->point_filter_rank_threshold }}" />
                                                 </div>

--- a/cncnet-api/resources/views/admin/ladder-setup.blade.php
+++ b/cncnet-api/resources/views/admin/ladder-setup.blade.php
@@ -376,6 +376,12 @@
                                                 </div>
 
                                                 <div class="form-group">
+                                                    <label for="{{ $rule->ladder_id }}_point_filter_rank_threshold">Min Rank for Pt Filter</label>
+                                                    <input id="{{ $rule->ladder_id }}_point_filter_rank_threshold" min="0" type="number" name="point_filter_rank_threshold" class="form-control"
+                                                        value="{{ $rule->point_filter_rank_threshold }}" />
+                                                </div>
+
+                                                <div class="form-group">
                                                     <?php $sideIdsAllowed = explode(',', $rule->allowed_sides); ?>
                                                     <label>Allowed Sides</label>
                                                     <div class="overflow-auto" style="height: 250px; overflow: auto; background: black;">


### PR DESCRIPTION
For no pt filter to be applied in matching, the player must be at least a certain rank for no pt filter to apply.
Rank threshold configurable in admin page