### PR TITLE
Catch empty space in email and use +

### DIFF
--- a/cncnet-api/app/Http/Controllers/ApiAuthController.php
+++ b/cncnet-api/app/Http/Controllers/ApiAuthController.php
@@ -51,16 +51,25 @@ class ApiAuthController extends Controller
 
     public function login(Request $request)
     {
-        $validator = Validator::make($request->all(), [
+        $email = $request->email;
+        if (str_contains($email, " "))
+        {
+            // Assume qm client has stripped + from email request
+            $email = str_replace(" ", "+", $email);
+        }
+
+        $validator = Validator::make(["email" => $email, "password" => $request->password], [
             'email' => 'required|string|email|max:255',
             'password' => 'required'
         ]);
+
         if ($validator->fails())
         {
             return response()->json($validator->errors(), 400);
         }
 
-        $credentials = $request->only('email', 'password');
+        $credentials = ["email" => $email, "password" => $request->password];
+
         try
         {
             if (!$token = JWTAuth::attempt($credentials))


### PR DESCRIPTION
User enters email as `email+email@gmail.com`. QM client sends up to auth endpoint as `email email@gmail.com`. Auth fails because it can't find the user. 

As opposed to patching the QM client, API auth endpoint changed to catch it instead.