### PR TITLE
Add ShouldBeUnique on the FindOpponentJob

### DIFF
--- a/cncnet-api/app/Jobs/Qm/FindOpponentJob.php
+++ b/cncnet-api/app/Jobs/Qm/FindOpponentJob.php
@@ -7,13 +7,14 @@ use App\Extensions\Qm\Matchup\PlayerMatchupHandler;
 use App\Extensions\Qm\Matchup\TeamMatchupHandler;
 use App\Models\QmQueueEntry;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
 
-class FindOpponentJob implements ShouldQueue
+class FindOpponentJob implements ShouldQueue, ShouldBeUnique
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
@@ -31,6 +32,13 @@ class FindOpponentJob implements ShouldQueue
 
         $this->qmQueueEntry = $qmQueueEntry;
         $this->gameType = $gameType;
+    }
+
+
+    public function uniqueId(): string
+    {
+        // this variable hold the id of the qm_queue_entry of the related player
+        return 'findmatch-' . $this->qmQueueEntry;
     }
 
     /**


### PR DESCRIPTION
Having 2 times the FindOpponentJob in the queue for the same player is not usefull.
We can ignore all new dispatch of the job until the one in the queue is processed.
This should help a lot to avoid having an overloaded queue.