### PR TITLE
Separate 1v1 and 2v2 on home page

### DIFF
--- a/cncnet-api/app/Http/Controllers/SiteController.php
+++ b/cncnet-api/app/Http/Controllers/SiteController.php
@@ -20,7 +20,8 @@ class SiteController extends Controller
 
         return view("index", [
             "news" => $news,
-            "ladders" => $ladderService->getLatestLadders(),
+            "ladders" => $ladderService->getLatestLadders(Ladder::ONE_VS_ONE),
+            "ladders_2v2" => $ladderService->getLatestLadders(Ladder::TWO_VS_TWO),
             "clan_ladders" => $ladderService->getLatestClanLadders(),
         ]);
     }

--- a/cncnet-api/app/Http/Services/LadderService.php
+++ b/cncnet-api/app/Http/Services/LadderService.php
@@ -76,9 +76,9 @@ class LadderService
         return $ladders;
     }
 
-    public function getLatestLadders()
+    public function getLatestLadders($ladderType = null)
     {
-        return Cache::remember("ladderService::getLatestLadders", 1 * 60, function ()
+        return Cache::remember("ladderService::getLatestLadders" . (isset($ladderType) ? $ladderType : ''), 1 * 60, function () use ($ladderType)
         {
             $date = Carbon::now();
 
@@ -89,6 +89,7 @@ class LadderService
                 ->where("ladder_history.starts", "=", $start)
                 ->where("ladder_history.ends", "=", $end)
                 ->whereNotNull("ladder.id")
+                ->when(isset($ladderType), function ($query) use ($ladderType) { $query->where("ladder_type", "=", $ladderType); })
                 ->where('ladder.clans_allowed', '=', false)
                 ->where('ladder.private', '=', false)
                 ->orderBy('ladder.order', 'ASC')

--- a/cncnet-api/resources/views/index.blade.php
+++ b/cncnet-api/resources/views/index.blade.php
@@ -73,7 +73,7 @@
                             military_tech
                         </span>
                     </div>
-                    <strong>Ranked</strong> Ladders
+                    <strong>Ranked</strong> Ladders | 1v1
                 </h2>
 
                 <div class="d-flex flex-wrap mt-4 player-ladders">
@@ -81,6 +81,28 @@
                         @include('components.ladder-box', [
                             'history' => $history,
                             'url' => \App\Models\URLHelper::getLadderUrl($history),
+                        ])
+                    @endforeach
+                </div>
+            </div>
+        </section>
+
+        <section class="pt-3 pb-3">
+            <div class="container-xl">
+                <h2>
+                    <div class="icon-box me-2">
+                        <span class="material-symbols-outlined icon color-gold" style="font-size: 2rem">
+                            military_tech
+                        </span>
+                    </div>
+                    <strong>Ranked</strong> Ladders | 2v2
+                </h2>
+
+                <div class="d-flex flex-wrap mt-4 player-ladders">
+                    @foreach ($ladders_2v2 as $history2)
+                        @include('components.ladder-box', [
+                            'history' => $history2,
+                            'url' => \App\Models\URLHelper::getLadderUrl($history2),
                         ])
                     @endforeach
                 </div>


### PR DESCRIPTION
Separate 1v1 and 2v2 in two different section on the homepage

![image](https://github.com/user-attachments/assets/b9aa3d69-8bde-48f6-b818-2986f1561074)
