### PR TITLE
Feature/fix points in player game reports2

### DIFF
--- a/cncnet-api/app/Http/Controllers/AdminController.php
+++ b/cncnet-api/app/Http/Controllers/AdminController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers;
 use App\Helpers\GameHelper;
 use App\Http\Services\AdminService;
 use App\Http\Services\LadderService;
-use App\Http\Services\PlayerService;
 use App\Models\Clan;
 use App\Models\GameObjectSchema;
 use App\Models\GameReport;
@@ -1197,7 +1196,6 @@ class AdminController extends Controller
     public function awardedPointsPreview(GameReport $gameReport, LadderHistory $history): array
     {
         $playerGameReports = $gameReport->playerGameReports()->with('player')->get();
-        $playerService = new PlayerService();
 
         if ($playerGameReports->count() !== 2) {
             return [];

--- a/cncnet-api/app/Http/Controllers/AdminController.php
+++ b/cncnet-api/app/Http/Controllers/AdminController.php
@@ -7,11 +7,13 @@ use App\Http\Services\AdminService;
 use App\Http\Services\LadderService;
 use App\Models\Clan;
 use App\Models\GameObjectSchema;
+use App\Models\GameReport;
 use App\Models\Ladder;
 use App\Models\LadderHistory;
 use App\Models\LadderType;
-use App\Models\PlayerCache;
 use App\Models\Player;
+use App\Models\PlayerCache;
+use App\Models\PlayerGameReport;
 use App\Models\SpawnOptionString;
 use App\Models\URLHelper;
 use App\Models\User;
@@ -1141,6 +1143,45 @@ class AdminController extends Controller
         $ladderHistory = $ladder->currentHistory();
 
         $bailedGames = $this->adminService->fetchBailedGames($ladderHistory)->get();
+    }
+
+
+    /**
+     * For points for games, which have
+     */
+    public function fixPoints(Request $request)
+    {
+        $request->validate([
+        'game_id' => 'required|exists:games,id',
+        'game_report_id' => 'required|exists:game_reports,id',
+        'mode' => 'required|in:zero_for_loser,plus10_minus10',
+        ]);
+
+
+        $report = GameReport::with('playerGameReports')->findOrFail($request->input('game_report_id'));
+
+        if ($report->playerGameReports->count() !== 2) {
+            return back()->with('error', 'Cannot fix other then 2-player-games.');
+        }
+
+        foreach ($report->playerGameReports as $pgr) {
+            if ($request->mode === 'plus10_minus10') {
+                $pgr->points = $pgr->won ? 10 : -10;
+            } elseif ($request->mode === 'zero_for_loser') {
+                if (!$pgr->won && $pgr->points > 0) {
+                    $pgr->points = 0;
+                }
+            }
+            $pgr->save();
+        }
+
+        Log::info('Fixed points ', [
+            'game_id' => $request->input('game_id'),
+            'report_id' => $report->id,
+            'by_admin' => auth()->id(),
+        ]);
+
+        return back()->with('success', 'Points fixed.');
     }
 }
 

--- a/cncnet-api/app/Http/Controllers/LadderController.php
+++ b/cncnet-api/app/Http/Controllers/LadderController.php
@@ -257,6 +257,26 @@ class LadderController extends Controller
         $playerGameReports = $gameReport->playerGameReports ?? [];
         $groupedPlayerGameReports = [];
 
+        $showBothPositiveFix = false;
+        $showBothZeroFix = false;
+        $fixedPointsPreview = [];
+
+        if (count($playerGameReports) === 2) {
+            $p1 = $playerGameReports[0];
+            $p2 = $playerGameReports[1];
+
+            $hasOneWinner = $p1->won != $p2->won;
+            $bothPositive = $p1->points > 0 && $p2->points > 0;
+            $bothZero = $p1->points == 0 && $p2->points == 0;
+
+            $showBothPositiveFix = $hasOneWinner && $bothPositive;
+            $showBothZeroFix = $hasOneWinner && $bothZero;
+
+            if ($showBothZeroFix && $userIsMod) {
+                $fixedPointsPreview = app(\App\Http\Controllers\AdminController::class)->awardedPointsPreview($gameReport, $history);
+            }
+        }
+
         if ($history->ladder->ladder_type == Ladder::TWO_VS_TWO)
         {
             $groupedPlayerGameReports = [];
@@ -349,6 +369,9 @@ class LadderController extends Controller
                     "qmMatchPlayers" => $qmMatchPlayers,
                     "tunnels" => $tunnels,
                     "date" => $date,
+                    "showBothPositiveFix" => $showBothPositiveFix,
+                    "showBothZeroFix" => $showBothZeroFix,
+                    "fixedPointsPreview" => $fixedPointsPreview,
                 ]
             );
         }
@@ -375,6 +398,9 @@ class LadderController extends Controller
                     "qmConnectionStats" => $qmConnectionStats,
                     "qmMatchPlayers" => $qmMatchPlayers,
                     "date" => $date,
+                    "showBothPositiveFix" => $showBothPositiveFix,
+                    "showBothZeroFix" => $showBothZeroFix,
+                    "fixedPointsPreview" => $fixedPointsPreview,
                 ]
             );
         }

--- a/cncnet-api/resources/views/ladders/game/_admin-game-tools.blade.php
+++ b/cncnet-api/resources/views/ladders/game/_admin-game-tools.blade.php
@@ -106,22 +106,43 @@
 
                                 $showBothPositiveFix = ($hasOneWinner && $bothPositive);
                                 $showBothZeroFix = ($hasOneWinner && $bothZero);
+
+                                $preview = app(\App\Http\Controllers\AdminController::class)->awardedPointsPreview($gameReport, $history);
+
                             }
                         @endphp
 
-                        @if ($showBothZeroFix && $userIsMod)
+                        @if ($thisGameReport->id === $gameReport->id && $showBothZeroFix && $gameReport->fps < $history->ladder->qmLadderRules->bail_fps)
+                            <div class="alert alert-info mt-4">
+                                <strong>FPS too low – no points awarded.</strong><br>Minimum FPS for this ladder is {{ $history->ladder->qmLadderRules->bail_fps}}.
+                            </div>
+                        @endif
+
+                        @if ($thisGameReport->id === $gameReport->id && $showBothZeroFix && $gameReport->duration < $history->ladder->qmLadderRules->bail_time)
+                            <div class="alert alert-info mt-4">
+                                <strong>Game duration too short – no points awarded.</strong><br>Minimum time for this ladder is {{ $history->ladder->qmLadderRules->bail_time}}.
+                            </div>
+                        @endif
+
+                        @if ($thisGameReport->id === $gameReport->id && $showBothZeroFix && $userIsMod && !empty($preview) && count($preview) === 2)
                         <form method="POST" action="/admin/moderate/{{ $history->ladder->id }}/games/fix-points" class="text-center mt-4">
                             @csrf
+                            @php
+                                $p1 = $preview[0];
+                                $p2 = $preview[1];
+                            @endphp
+                            <input type="hidden" name="player_points[{{ $playerGameReports[0]->player_id }}]" value="{{ $p1['calculated_points'] }}">
+                            <input type="hidden" name="player_points[{{ $playerGameReports[1]->player_id }}]" value="{{ $p2['calculated_points'] }}">
                             <input type="hidden" name="game_id" value="{{ $game->id }}">
                             <input type="hidden" name="game_report_id" value="{{ $gameReport->id }}">
-                            <input type="hidden" name="mode" value="plus10_minus10">
+                            <input type="hidden" name="mode" value="fix_points">
                             <button type="submit" class="btn btn-outline-secondary">
-                                Set points to +10/-10.
+                                Fix points ({{ $preview[0]['player'] }}: {{ $preview[0]['calculated_points'] >= 0 ? '+' : '' }}{{ $preview[0]['calculated_points'] }}, {{ $preview[1]['player'] }}: {{ $preview[1]['calculated_points'] >= 0 ? '+' : '' }}{{ $preview[1]['calculated_points'] }})
                             </button>
                         </form>
                         @endif
 
-                        @if ($showBothPositiveFix && $userIsMod)
+                        @if ($thisGameReport->id === $gameReport->id && $showBothPositiveFix && $userIsMod)
                         <form method="POST" action="/admin/moderate/{{ $history->ladder->id }}/games/fix-points" class="text-center mt-4">
                             @csrf
                             <input type="hidden" name="game_id" value="{{ $game->id }}">

--- a/cncnet-api/resources/views/ladders/game/_admin-game-tools.blade.php
+++ b/cncnet-api/resources/views/ladders/game/_admin-game-tools.blade.php
@@ -127,12 +127,9 @@
                         @if ($thisGameReport->id === $gameReport->id && $showBothZeroFix && $userIsMod && !empty($preview) && count($preview) === 2)
                         <form method="POST" action="/admin/moderate/{{ $history->ladder->id }}/games/fix-points" class="text-center mt-4">
                             @csrf
-                            @php
-                                $p1 = $preview[0];
-                                $p2 = $preview[1];
-                            @endphp
-                            <input type="hidden" name="player_points[{{ $playerGameReports[0]->player_id }}]" value="{{ $p1['calculated_points'] }}">
-                            <input type="hidden" name="player_points[{{ $playerGameReports[1]->player_id }}]" value="{{ $p2['calculated_points'] }}">
+                            @foreach ($preview as $entry)
+                                <input type="hidden" name="player_points[{{ $entry['player_id'] }}]" value="{{ $entry['calculated_points'] }}">
+                            @endforeach
                             <input type="hidden" name="game_id" value="{{ $game->id }}">
                             <input type="hidden" name="game_report_id" value="{{ $gameReport->id }}">
                             <input type="hidden" name="mode" value="fix_points">

--- a/cncnet-api/resources/views/ladders/game/_admin-game-tools.blade.php
+++ b/cncnet-api/resources/views/ladders/game/_admin-game-tools.blade.php
@@ -86,32 +86,6 @@
                             @endif
                         @endforeach
 
-                       @php
-                            $pgrs = $playerGameReports;
-                            $showBothPositiveFix = false;
-                            $showBothZeroFix = false;
-
-                            if ($pgrs->count() === 2) {
-                                $p1 = $pgrs[0];
-                                $p2 = $pgrs[1];
-
-                                // Only fix points if there's a clear winner.
-                                $hasOneWinner = $p1->won != $p2->won;
-
-                                // Fix 1: both players got positive points.
-                                $bothPositive = $p1->points > 0 && $p2->points > 0;
-
-                                // Fix 2: both players got zero points.
-                                $bothZero = $p1->points == 0 && $p2->points == 0;
-
-                                $showBothPositiveFix = ($hasOneWinner && $bothPositive);
-                                $showBothZeroFix = ($hasOneWinner && $bothZero);
-
-                                $preview = app(\App\Http\Controllers\AdminController::class)->awardedPointsPreview($gameReport, $history);
-
-                            }
-                        @endphp
-
                         @if ($thisGameReport->id === $gameReport->id && $showBothZeroFix && $gameReport->fps < $history->ladder->qmLadderRules->bail_fps)
                             <div class="alert alert-info mt-4">
                                 <strong>FPS too low – no points awarded.</strong><br>Minimum FPS for this ladder is {{ $history->ladder->qmLadderRules->bail_fps}}.
@@ -124,17 +98,17 @@
                             </div>
                         @endif
 
-                        @if ($thisGameReport->id === $gameReport->id && $showBothZeroFix && $userIsMod && !empty($preview) && count($preview) === 2)
+                        @if ($thisGameReport->id === $gameReport->id && $showBothZeroFix && $userIsMod && !empty($fixedPointsPreview) && count($fixedPointsPreview) === 2)
                         <form method="POST" action="/admin/moderate/{{ $history->ladder->id }}/games/fix-points" class="text-center mt-4">
                             @csrf
-                            @foreach ($preview as $entry)
+                            @foreach ($fixedPointsPreview as $entry)
                                 <input type="hidden" name="player_points[{{ $entry['player_id'] }}]" value="{{ $entry['calculated_points'] }}">
                             @endforeach
                             <input type="hidden" name="game_id" value="{{ $game->id }}">
                             <input type="hidden" name="game_report_id" value="{{ $gameReport->id }}">
                             <input type="hidden" name="mode" value="fix_points">
                             <button type="submit" class="btn btn-outline-secondary">
-                                Fix points ({{ $preview[0]['player'] }}: {{ $preview[0]['calculated_points'] >= 0 ? '+' : '' }}{{ $preview[0]['calculated_points'] }}, {{ $preview[1]['player'] }}: {{ $preview[1]['calculated_points'] >= 0 ? '+' : '' }}{{ $preview[1]['calculated_points'] }})
+                                Fix points ({{ $fixedPointsPreview[0]['player'] }}: {{ $fixedPointsPreview[0]['calculated_points'] >= 0 ? '+' : '' }}{{ $fixedPointsPreview[0]['calculated_points'] }}, {{ $fixedPointsPreview[1]['player'] }}: {{ $fixedPointsPreview[1]['calculated_points'] >= 0 ? '+' : '' }}{{ $fixedPointsPreview[1]['calculated_points'] }})
                             </button>
                         </form>
                         @endif
@@ -146,7 +120,7 @@
                             <input type="hidden" name="game_report_id" value="{{ $gameReport->id }}">
                             <input type="hidden" name="mode" value="zero_for_loser">
                             <button type="submit" class="btn btn-outline-secondary">
-                               Fix points for loser.
+                               Set points for loser to 0
                             </button>
                         </form>
                         @endif

--- a/cncnet-api/resources/views/ladders/game/_admin-game-tools.blade.php
+++ b/cncnet-api/resources/views/ladders/game/_admin-game-tools.blade.php
@@ -86,6 +86,53 @@
                             @endif
                         @endforeach
 
+                       @php
+                            $pgrs = $playerGameReports;
+                            $showBothPositiveFix = false;
+                            $showBothZeroFix = false;
+
+                            if ($pgrs->count() === 2) {
+                                $p1 = $pgrs[0];
+                                $p2 = $pgrs[1];
+
+                                // Only fix points if there's a clear winner.
+                                $hasOneWinner = $p1->won != $p2->won;
+
+                                // Fix 1: both players got positive points.
+                                $bothPositive = $p1->points > 0 && $p2->points > 0;
+
+                                // Fix 2: both players got zero points.
+                                $bothZero = $p1->points == 0 && $p2->points == 0;
+
+                                $showBothPositiveFix = ($hasOneWinner && $bothPositive);
+                                $showBothZeroFix = ($hasOneWinner && $bothZero);
+                            }
+                        @endphp
+
+                        @if ($showBothZeroFix && $userIsMod)
+                        <form method="POST" action="/admin/moderate/{{ $history->ladder->id }}/games/fix-points" class="text-center mt-4">
+                            @csrf
+                            <input type="hidden" name="game_id" value="{{ $game->id }}">
+                            <input type="hidden" name="game_report_id" value="{{ $gameReport->id }}">
+                            <input type="hidden" name="mode" value="plus10_minus10">
+                            <button type="submit" class="btn btn-outline-secondary">
+                                Set points to +10/-10.
+                            </button>
+                        </form>
+                        @endif
+
+                        @if ($showBothPositiveFix && $userIsMod)
+                        <form method="POST" action="/admin/moderate/{{ $history->ladder->id }}/games/fix-points" class="text-center mt-4">
+                            @csrf
+                            <input type="hidden" name="game_id" value="{{ $game->id }}">
+                            <input type="hidden" name="game_report_id" value="{{ $gameReport->id }}">
+                            <input type="hidden" name="mode" value="zero_for_loser">
+                            <button type="submit" class="btn btn-outline-secondary">
+                               Fix points for loser.
+                            </button>
+                        </form>
+                        @endif
+
                         @if ($thesePlayerGameReports->count() < 1)
                             <form action="/admin/moderate/{{ $history->ladder->id }}/games/switch" class="text-center" method="POST">
                                 <input type="hidden" name="_token" value="{{ csrf_token() }}">

--- a/cncnet-api/routes/web.php
+++ b/cncnet-api/routes/web.php
@@ -179,6 +179,7 @@ Route::group(['prefix' => 'admin'], function ()
             Route::post('/games/{cncnetGame}/delete', [AdminController::class, 'deleteGame']);
             Route::post('/games/switch', [AdminController::class, 'switchGameReport']);
             Route::post('/games/wash', [AdminController::class, 'washGame']);
+            Route::post('/games/fix-points', [AdminController::class, 'fixPoints']);
 
             Route::get('/player/{playerId}', [AdminController::class, 'getLadderPlayer']);
             Route::get('/player/{playerId}/newban/{banType}', [AdminController::class, 'getUserBan']);


### PR DESCRIPTION
Messed up old branch. Here's a new one. Uses a lot less code now.

Meant to fix games like this:
[Loser gets points](https://ladder.cncnet.org/ladder/6-2025/blitz/games/1035421)
[No points assigned, despite clear winner](https://ladder.cncnet.org/ladder/6-2025/ra/games/1033593)

Second game had no points due to low FPS - noticed it too late. 

Fix:
- Adds “Fix points for loser” (sets loser's points to 0 if both got positive points)
- Adds “Fix points” button if both got 0 but there’s a clear winner

Options we still have:

1. Discard everything (fine by me)
2. Keep info boxes only
3. Keep info boxes and "Fix points for loser" button
4. Use the full version
