### PR TITLE
Mount crontab for copying.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,7 +121,7 @@ services:
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
       MYSQL_PORT: 3306
     volumes:
-      - ./docker/elogen/crontab:/etc/cron.d/elogen-cron:ro
+      - ./docker/elogen/crontab:/mnt/crontab:ro
       - ./storage/app/rating:/data
     depends_on:
       - mysql

--- a/docker/elogen/crontab
+++ b/docker/elogen/crontab
@@ -1,8 +1,8 @@
 # Daily jobs
-10 5 * * * cncnet /app/elogen -o /data -m blitz -l info
-20 5 * * * cncnet /app/elogen -o /data -m ra2 -l info
-30 5 * * * cncnet /app/elogen -o /data -m yr -l info
-40 5 * * * cncnet /app/elogen -o /data -m blitz-2v2 -l info
+10 5 * * * cncnet /app/elogen -o /data -m ra2 -l info
+30 5 * * * cncnet /app/elogen -o /data -m blitz-2v2 -l info
+40 5 * * * cncnet /app/elogen -o /data -m yr -l info
 
-# Weekly job
-50 5 * * 0 cncnet /app/elogen -o /data -m ra -l info
+# Three times a week
+55 5 * * 1,3,5 cncnet /app/elogen -o /data -m blitz -l info
+10 6 * * 1,3,5 cncnet /app/elogen -o /data -m ra -l info


### PR DESCRIPTION
New entrypoint for Docker container elogen:

https://github.com/CnCNet/cncnet-ladder-elo-computation/blob/main/Dockerfile#L57

This is the script:

https://github.com/CnCNet/cncnet-ladder-elo-computation/blob/main/entrypoint-cron.sh

Copies crontab to corresponding folder and changes owner to root. Otherwise cron will not run the jobs.
