### PR TITLE
Dedicated logging for deprecation warnings

### DIFF
--- a/cncnet-api/config/logging.php
+++ b/cncnet-api/config/logging.php
@@ -89,6 +89,13 @@ return [
             'driver' => 'errorlog',
             'level' => env('LOG_LEVEL', 'debug'),
         ],
+
+        'deprecations' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/laravel_DEPRECATIONS.log'),
+            'level' => env('LOG_LEVEL', 'debug'),
+            'days' => 7,
+        ],
     ],
 
 ];


### PR DESCRIPTION
Creates file with deprecation warnings instead of using emergency logger. Tested locally. Refers to
https://discord.com/channels/1089195585984286860/1089944165632180296/1383644832903462945