### PR TITLE
middleware: fix Restrict middleware

### DIFF
--- a/cncnet-api/app/Http/Middleware/Restrict.php
+++ b/cncnet-api/app/Http/Middleware/Restrict.php
@@ -35,6 +35,10 @@ class Restrict
      */
     public function handle(Request $request, Closure $next, string $permission): Response
     {
+        if($this->auth->guest() || $this->auth->user() === null) {
+            return response('Unauthorized.', 401);
+        }
+
         if (!$this->auth->user()->isGod())
         {
             $response = null;


### PR DESCRIPTION
[2025-06-18 16:28:48] production.ERROR: Call to a member function isGod() on null {"exception":"[object] (Error(code: 0): Call to a member function isGod() on null at /app/app/Http/Middleware/Restrict.php:38)
[stacktrace]
#0 /app/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(209): App\\Http\\Middleware\\Restrict->handle()
#1 /app/vendor/barryvdh/laravel-debugbar/src/Middleware/InjectDebugbar.php(59): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#2 /app/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(209): Barryvdh\\Debugbar\\Middleware\\InjectDebugbar->handle()
#3 /app/vendor/laravel/framework/src/Illuminate/Routing/Middleware/SubstituteBindings.php(51): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()