### PR TITLE
Fixed ladder game report link.

### DIFF
--- a/cncnet-api/resources/views/components/ladder/listing/game-box.blade.php
+++ b/cncnet-api/resources/views/components/ladder/listing/game-box.blade.php
@@ -2,7 +2,7 @@
 @php
     $mapName = $game->qmMatch?->map?->description;
 @endphp
-<a href="{{ '/ladder/' . $history->short . '/' . $history->ladder->abbreviation . '/games/' . $game->id }}" class="game-box"
+<a href="{{ route('ladder.game', ['date' => $history->short, 'game' => $history->ladder->abbreviation, 'gameId' => $game->id]) }}" class="game-box"
     data-timestamp="{{ $game->updated_at->timestamp }}">
 
     <div class="map-preview">

--- a/cncnet-api/resources/views/ladders/game/_admin-game-tools.blade.php
+++ b/cncnet-api/resources/views/ladders/game/_admin-game-tools.blade.php
@@ -70,7 +70,7 @@
                             @if ($k == 0)
                                 @if ($userIsMod && $thisGameReport->id != $gameReport->id)
                                     <a class="btn btn-outline-secondary"
-                                        href="{{ action([\App\Http\Controllers\LadderController::class, 'getLadderGame'], ['date' => $date, 'game' => $cncnetGame, 'gameId' => $game->id, 'reportId' => $thisGameReport->id]) }}">View</a>
+                                        href="{{ route('ladder.game.report', ['date' => $date, 'game' => $cncnetGame, 'gameId' => $game->id, 'reportId' => $thisGameReport->id]) }}">View</a>
                                 @elseif ($userIsMod && $thisGameReport->id == $gameReport->id && !$thisGameReport->best_report)
                                     <form action="/admin/moderate/{{ $history->ladder->id }}/games/switch" class="text-center" method="POST">
                                         <input type="hidden" name="_token" value="{{ csrf_token() }}">

--- a/cncnet-api/routes/web.php
+++ b/cncnet-api/routes/web.php
@@ -33,8 +33,8 @@ Route::group(['prefix' => 'ladder/', 'middleware' => ['cache.public']], function
     Route::get('{date}/{game}/clan/{clan}', [\App\Http\Controllers\LadderController::class, 'getLadderClan']);
     Route::get('{date}/{game}/clan/{clan}/achievements', [\App\Http\Controllers\LadderController::class, 'getPlayerAchievementsPage']);
 
-    Route::get('{date}/{game}/games/{gameId}', [\App\Http\Controllers\LadderController::class, 'getLadderGame']);
-    Route::get('{date}/{game}/games/{gameId}/{reportId}', [\App\Http\Controllers\LadderController::class, 'getLadderGame']);
+    Route::get('{date}/{game}/games/{gameId}', [\App\Http\Controllers\LadderController::class, 'getLadderGame'])->name('ladder.game');
+    Route::get('{date}/{game}/games/{gameId}/{reportId}', [\App\Http\Controllers\LadderController::class, 'getLadderGame'])->name('ladder.game.report');
 });
 
 # Clan Ladders


### PR DESCRIPTION
Switching the routes (moving the more specific one to the top) does not fix the links. Laravel still adds the reportId as a query parameter. Using named routes is the safest way to ensure that route parameters are included in the URL path rather than being appended as query strings.