### PR TITLE
fix bug where disconnect gave everyone minus points

### DIFF
--- a/cncnet-api/app/Extensions/Qm/Matchup/BaseMatchupHandler.php
+++ b/cncnet-api/app/Extensions/Qm/Matchup/BaseMatchupHandler.php
@@ -33,14 +33,17 @@ abstract class BaseMatchupHandler
     public function createMatch(Collection $maps, Collection $otherQMQueueEntries)
     {
         // filter out placeholder maps
-        $filteredMaps = $maps->filter(function ($map) {
-            return
-                !strpos($map->description, 'Map Info')
-                && !strpos($map->description, 'Map Guide')
-                && !strpos($map->description, 'Ladder Guide')
-                && !strpos($map->description, 'Ladder Info')
-                && !strpos($map->description, 'Ladder Rules');
+        $filteredMaps = $maps->filter(function ($map)
+        {
+            return !(
+                str_contains($map->description, 'Map Info') ||
+                str_contains($map->description, 'Map Guide') ||
+                str_contains($map->description, 'Ladder Guide') ||
+                str_contains($map->description, 'Ladder Info') ||
+                str_contains($map->description, 'Ladder Rules')
+            );
         });
+
 
         $this->removeQueueEntry();
 


### PR DESCRIPTION
Dug into a 2v2 match that ended in disconnect. Every player game report had won=0, currently 2v2 logic is looking for won=1 to get the winner. Added a fallback to look if a player was defeated, their team is now the loser.

Also if winningTeam is null, give +0 to all.