### PR TITLE
Feature/refactor user ratings

### DIFF
--- a/cncnet-api/app/Http/Controllers/AdminController.php
+++ b/cncnet-api/app/Http/Controllers/AdminController.php
@@ -1469,6 +1469,11 @@ class AdminController extends Controller
 
             $users = User::join("user_ratings as ur", "ur.user_id", "=", "users.id")
                 ->orderBy("ur.rating", "DESC")
+                ->where("ur.ladder_id", $ladder->id)
+                ->where(function ($query) {
+                    $query->whereNull("users.primary_user_id")
+                        ->orWhereColumn("users.primary_user_id", "users.id");
+                })
                 ->whereIn("users.id", $byPlayer->pluck("user_id"))
                 ->select(["users.*", "ur.rating", "ur.rated_games"])
                 ->paginate(50);
@@ -1477,7 +1482,12 @@ class AdminController extends Controller
         {
             $users = User::join("user_ratings as ur", "ur.user_id", "=", "users.id")
                 ->orderBy("ur.rating", "DESC")
-                ->select(["users.*", "ur.rating", "ur.rated_games"])
+                ->where("ur.ladder_id", $ladder->id)
+                ->where(function ($query) {
+                    $query->whereNull("users.primary_user_id")
+                        ->orWhereColumn("users.primary_user_id", "users.id");
+                })
+                ->select(["users.*", "ur.rating", "ur.rated_games", "ur.deviation"])
                 ->paginate(50);
         }
 

--- a/cncnet-api/app/Http/Controllers/AdminController.php
+++ b/cncnet-api/app/Http/Controllers/AdminController.php
@@ -1470,14 +1470,14 @@ class AdminController extends Controller
             $users = User::join("user_ratings as ur", "ur.user_id", "=", "users.id")
                 ->orderBy("ur.rating", "DESC")
                 ->whereIn("users.id", $byPlayer->pluck("user_id"))
-                ->select(["users.*", "ur.rating", "ur.rated_games", "ur.peak_rating"])
+                ->select(["users.*", "ur.rating", "ur.rated_games"])
                 ->paginate(50);
         }
         else
         {
             $users = User::join("user_ratings as ur", "ur.user_id", "=", "users.id")
                 ->orderBy("ur.rating", "DESC")
-                ->select(["users.*", "ur.rating", "ur.rated_games", "ur.peak_rating"])
+                ->select(["users.*", "ur.rating", "ur.rated_games"])
                 ->paginate(50);
         }
 

--- a/cncnet-api/app/Http/Controllers/AdminController.php
+++ b/cncnet-api/app/Http/Controllers/AdminController.php
@@ -1475,7 +1475,7 @@ class AdminController extends Controller
                         ->orWhereColumn("users.primary_user_id", "users.id");
                 })
                 ->whereIn("users.id", $byPlayer->pluck("user_id"))
-                ->select(["users.*", "ur.rating", "ur.rated_games"])
+                ->select(["users.*", "ur.rating", "ur.rated_games", "ur.deviation"])
                 ->paginate(50);
         }
         else

--- a/cncnet-api/app/Http/Controllers/ApiLadderController.php
+++ b/cncnet-api/app/Http/Controllers/ApiLadderController.php
@@ -790,7 +790,7 @@ class ApiLadderController extends Controller
 
     public function getLadderPlayer(Request $request, $game = null, $player = null)
     {
-        $date = Carbon::now()->format('m-Y');
+        $date = $request->query('date') ?? Carbon::now()->format('m-Y');
         $ladderService = $this->ladderService;
         return Cache::remember("getLadderPlayer/$date/$game/$player", 5 * 60, function () use ($ladderService, $date, $game, $player)
         {
@@ -801,7 +801,7 @@ class ApiLadderController extends Controller
 
     public function getLadderPlayerFromPublicApi(Request $request, $game = null, $player = null)
     {
-        $date = Carbon::now()->format('m-Y');
+        $date = $request->query('date') ?? Carbon::now()->format('m-Y');
         $ladderService = $this->ladderService;
         return Cache::remember("getLadderPlayerFromPublicApi/$date/$game/$player", 5 * 60, function () use ($ladderService, $date, $game, $player)
         {

--- a/cncnet-api/app/Http/Controllers/ApiUserController.php
+++ b/cncnet-api/app/Http/Controllers/ApiUserController.php
@@ -26,7 +26,21 @@ class ApiUserController extends Controller
         try
         {
             $user = $request->user();
-            return $user;
+
+            $elo = $user->userRatings()->get([
+                'ladder_id',
+                'rating',
+                'deviation',
+                'elo_rank',
+                'alltime_rank',
+                'rated_games',
+                'active',
+            ]);
+
+            $userData = $user->toArray();
+            $userData['elo'] = $elo;
+
+            return $userData;
         }
         catch (Exception $ex)
         {

--- a/cncnet-api/app/Http/Controllers/LadderController.php
+++ b/cncnet-api/app/Http/Controllers/LadderController.php
@@ -476,7 +476,7 @@ class LadderController extends Controller
         $recentAchievements = $this->achievementService->getRecentlyUnlockedAchievements($history, $user, 3);
         $achievementProgressCounts = $this->achievementService->getProgressCountsByUser($history, $user);
 
-        $isAnonymous = $player->user->userSettings->is_anonymous;
+        $isAnonymous = $player->user->userSettings->is_anonymous && ($history->id == $currentHistory->id);
 
         $ladderNicks = [];
         if (!$isAnonymous && $history->id != $currentHistory->id) // only hide if anonymous and is the current month

--- a/cncnet-api/app/Http/Controllers/LadderController.php
+++ b/cncnet-api/app/Http/Controllers/LadderController.php
@@ -409,7 +409,6 @@ class LadderController extends Controller
     public function getLadderPlayer(Request $request, $date = null, $cncnetGame = null, $username = null)
     {
         $history = $this->ladderService->getActiveLadderByDate($date, $cncnetGame);
-        $currentHistory = $history->ladder->currentHistory();
 
         if ($history == null)
         {
@@ -476,10 +475,10 @@ class LadderController extends Controller
         $recentAchievements = $this->achievementService->getRecentlyUnlockedAchievements($history, $user, 3);
         $achievementProgressCounts = $this->achievementService->getProgressCountsByUser($history, $user);
 
-        $isAnonymous = $player->user->userSettings->is_anonymous && ($history->id == $currentHistory->id);
+        $isAnonymous = $player->user->userSettings->getIsAnonymousForLadderHistory($history);
 
         $ladderNicks = [];
-        if (!$isAnonymous && $history->id != $currentHistory->id) // only hide if anonymous and is the current month
+        if (!$isAnonymous) // only hide if anonymous and is the current month
         {
             $ladderNicks = $user->usernames
                 ->where('id', '!=', $player->id)

--- a/cncnet-api/app/Http/Services/LadderService.php
+++ b/cncnet-api/app/Http/Services/LadderService.php
@@ -8,7 +8,6 @@ use App\Models\Game;
 use App\Models\Ladder;
 use App\Models\LadderHistory;
 use App\Models\PlayerCache;
-use App\Models\PlayerRating;
 use App\Models\Side;
 use Carbon\Carbon;
 use Carbon\Exceptions\InvalidFormatException;

--- a/cncnet-api/app/Http/Services/PlayerService.php
+++ b/cncnet-api/app/Http/Services/PlayerService.php
@@ -80,7 +80,7 @@ class PlayerService
     {
         $player = Player::find($pid);
         $user = $player->user;
-        $userRating = $user->getOrCreateLiveUserRating();
+        $userRating = $user->getEffectiveUserRating();
 
         return $userRating;
     }

--- a/cncnet-api/app/Http/Services/QuickMatchService.php
+++ b/cncnet-api/app/Http/Services/QuickMatchService.php
@@ -625,12 +625,12 @@ class QuickMatchService
         else if ($ladderRules->use_elo_map_picker) // consider a player's ELO when selecting a map
         {
             $matchAnyMap = false;
-            $myEloRating = $qmPlayer->player->user->getOrCreateLiveUserRating()->rating;
+            $myEloRating = $qmPlayer->player->user->getEffectiveUserRatingForLadder($history->ladder->id)->rating;
 
             foreach ($otherQMQueueEntries as $otherQMQueueEntry)
             {
                 // choose the person who has the lowest elo rating to base our map pick off of
-                $minEloRating = min($myEloRating, $otherQMQueueEntry->qmPlayer->player->user->getOrCreateLiveUserRating()->rating);
+                $minEloRating = min($myEloRating, $otherQMQueueEntry->qmPlayer->player->user->getEffectiveUserRatingForLadder($history->ladder->id)->rating);
 
                 // true if both players allow any map
                 $matchAnyMap = $otherQMQueueEntry->qmPlayer->player->user->userSettings->match_any_map

--- a/cncnet-api/app/Models/LadderHistory.php
+++ b/cncnet-api/app/Models/LadderHistory.php
@@ -47,4 +47,10 @@ class LadderHistory extends Model
             });
     }
 
+    public function isCurrent(): bool
+    {
+        $now = Carbon::now();
+        return $this->starts->month === $now->month && $this->starts->year === $now->year;
+    }
+
 }

--- a/cncnet-api/app/Models/User.php
+++ b/cncnet-api/app/Models/User.php
@@ -392,18 +392,36 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
     }
 
     /**
-     * Returns live user rating or creates a new one if one doesn't exist yet
-     * @return mixed 
+     * Get a default rating in case the user hasn't one yet.
+     * @return UserRating
      */
-    public function getOrCreateLiveUserRating()
+    protected function getDefaultUserRating($ladderId): UserRating
     {
-        $userRating = UserRating::where("user_id", "=", $this->id)->first();
-        if ($userRating == null)
-        {
-            $userRating = UserRating::createNewFromLegacyPlayerRating($this);
-            Log::info("User ** getUserRating - Rating null creating new. UserId: " . $this->id  . " Created new user rating: " . $userRating);
-        }
-        return $userRating;
+        return UserRating::make([
+            'user_id'      => $this->id,
+            'ladder_id'    => $ladderId,
+            'rating'       => UserRating::$DEFAULT_RATING,
+            'elo_rank'     => 0,
+            'deviation'    => 350,
+            'alltime_rank' => 0,
+            'rated_games'  => 0,
+            'active'       => false,
+        ]);
+    }
+
+    /**
+     * Returns live user rating. Note that the player might be inactive.
+     * @return mixed
+     */
+    public function getEffectiveUserRatingForLadder($ladderId)
+    {
+        $primaryUser = $this->isDuplicate() ? User::find($this->primaryId()) : $this;
+
+        $rating = $primaryUser->userRatings()
+            ->where('ladder_id', $ladderId)
+            ->first();
+
+        return $rating ?? $this->getDefaultUserRating($ladderId);
     }
 
     /**
@@ -416,7 +434,6 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
         $userRating = $this->getOrCreateLiveUserRating();
         return UserRatingService::getTierByLadderRules($userRating->rating, $history->ladder);
     }
-
 
     /**
      * 
@@ -455,12 +472,17 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
         return $this->collectDuplicates($includeSelf = true)->pluck('created_at')->filter()->min()->diffForHumans();
     }
 
+    public function alias()
+    {
+        $primaryUser = $this->isDuplicate() ? User::find($this->primaryId()) : $this;
+        return $primaryUser->alias;
+    }
+
     public function canUserPlayBothTiers($ladder)
     {
         $userTier = $this->getUserLadderTier($ladder);
         return $userTier->both_tiers;
     }
-
 
     /**
      * Returns true when the user only wants pro only matchups
@@ -496,9 +518,9 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
         return $this->hasMany(AchievementProgress::class, 'user_id');
     }
 
-    public function userRating()
+    public function userRatings()
     {
-        return $this->hasOne(UserRating::class, 'user_id');
+        return $this->hasMany(UserRating::class, 'user_id');
     }
 
     public function ipHistory()

--- a/cncnet-api/app/Models/UserRating.php
+++ b/cncnet-api/app/Models/UserRating.php
@@ -8,58 +8,26 @@ class UserRating extends Model
 {
     public static $DEFAULT_RATING = 1200;
 
-    public function __construct()
+    protected $table = 'user_ratings';
+
+    protected $fillable = [
+        'user_id', 'ladder_id', 'rating', 'deviation', 'elo_rank', 'alltime_rank', 'rated_games', 'active',
+    ];
+
+    public $timestamps = true;
+
+    public function save(array $options = [])
     {
-        $this->rating = UserRating::$DEFAULT_RATING;
-        $this->peak_rating = 0;
-        $this->rated_games = 0;
+        throw new \Exception("UserRating is read-only.");
     }
 
-    public static function createNew($user, $rating, $ratedGames, $peakRating)
+    public function delete()
     {
-        $userRating = new UserRating();
-        $userRating->rating = $rating;
-        $userRating->rated_games = $ratedGames;
-        $userRating->peak_rating = $peakRating;
-        $userRating->user_id = $user->id;
-        $userRating->save();
-        return $userRating;
-    }
-
-    /**
-     * Creates on demand UserRatings from old player_ratings table
-     * @param mixed $user 
-     * @return UserRating 
-     */
-    public static function createNewFromLegacyPlayerRating($user)
-    {
-        # Take player usernames from user 
-        $userPlayerIds = $user->usernames()->pluck("id")->toArray();
-
-        # Find legacy Player rating for all the nicks this user owns
-        # Grab highest rating with at least one rated game
-        $playerRating = PlayerRating::whereIn("player_id", $userPlayerIds)
-            ->where("rated_games", ">", 0)
-            ->orderBy("rating", "DESC")
-            ->select(["rating", "peak_rating", "rated_games"])
-            ->first();
-
-        $ratedGames = 0;
-        $peakRating = 0;
-        $rating = UserRating::$DEFAULT_RATING;
-
-        if ($playerRating)
-        {
-            $rating = $playerRating->rating;
-            $ratedGames = $playerRating->rated_games;
-            $peakRating = $playerRating->peak_rating;
-        }
-
-        return UserRating::createNew($user, $rating, $ratedGames, $peakRating);
+        throw new \Exception("UserRating is read-only.");
     }
 
     public function user()
     {
-        return $this->hasOne(User::class);
+        return $this->belongsTo(User::class);
     }
 }

--- a/cncnet-api/app/Models/UserSettings.php
+++ b/cncnet-api/app/Models/UserSettings.php
@@ -42,4 +42,10 @@ class UserSettings extends Model
     {
         return $this->is_anonymous == true;
     }
+
+    public function getIsAnonymousForLadderHistory(LadderHistory $history): bool
+    {
+        // Only anonymous in current month.
+        return $this->is_anonymous && $history->isCurrent();
+    }
 }

--- a/cncnet-api/database/migrations/2025_08_01_004937_switch_to_elo_for_using_ratings_table.php
+++ b/cncnet-api/database/migrations/2025_08_01_004937_switch_to_elo_for_using_ratings_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('user_ratings', function (Blueprint $table) {
+            $table->dropColumn('peak_rating');
+        });
+
+        Schema::table('user_ratings', function (Blueprint $table) {
+            $table->unsignedInteger('ladder_id')->after('user_id');
+            $table->integer('deviation')->after('rating');
+            $table->integer('elo_rank')->after('deviation');
+            $table->integer('alltime_rank')->after('elo_rank');
+            $table->boolean('active')->default(1)->after('rated_games');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('user_ratings', function (Blueprint $table) {
+            $table->integer('peak_rating');
+            $table->dropColumn(['ladder_id', 'deviation', 'elo_rank', 'alltime_rank', 'active']);
+        });
+    }
+};

--- a/cncnet-api/resources/stylesheets/pages/player-detail/_index.scss
+++ b/cncnet-api/resources/stylesheets/pages/player-detail/_index.scss
@@ -273,3 +273,49 @@ body.body-player-detail .page-image-feature
     margin-right: 0.5rem;
     margin-bottom: 0.5rem;
 }
+
+.player-detail .tooltip
+{
+    position: relative;
+    display: inline-block;
+    cursor: pointer;
+}
+
+.player-detail .tooltip .tooltiptext
+{
+    visibility: hidden;
+    width: 256px;
+    background-color: #292929;
+    color: #b7b7b7;
+    text-align: center;
+    border-radius: 4px;
+    border-width: 1px;
+    border-style: solid;
+    border-color:gray;
+    padding: 5px;
+    position: absolute;
+    z-index: 1;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    opacity: 0;
+    transition: opacity 0.3s;
+}
+
+.player-detail .tooltip .tooltiptext::after
+{
+    content: "";
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border-width: 3px;
+    border-style: solid;
+    border-color: transparent transparent black transparent;
+}
+
+.player-detail .tooltip:hover .tooltiptext
+{
+    visibility: visible;
+    opacity: 1;
+}

--- a/cncnet-api/resources/views/admin/players/ratings.blade.php
+++ b/cncnet-api/resources/views/admin/players/ratings.blade.php
@@ -157,8 +157,8 @@
 
                                         <td>
                                             Rating: {{ $user->rating }} <br />
-                                            Rated games:{{ $user->rated_games }}<br />
-                                            Peek rating: {{ $user->peak_rating }} <br />
+                                            Rated games: {{ $user->rated_games }}<br />
+                                            Deviation: {{ $user->deviation }} <br />
                                         </td>
                                     </tr>
                                 @endforeach

--- a/cncnet-api/resources/views/auth/account-settings.blade.php
+++ b/cncnet-api/resources/views/auth/account-settings.blade.php
@@ -83,10 +83,6 @@
             @include('auth.account-settings-nav')
         </div>
 
-        <div>
-            <h4>Ladder Elo: {{ $user->getOrCreateLiveUserRating()->rating }}</h4>
-        </div>
-
         <div class="row">
             <div class="col-md-12">
                 <form method="POST" action="/account/settings" enctype="multipart/form-data">

--- a/cncnet-api/resources/views/components/ladder/listing/player-row.blade.php
+++ b/cncnet-api/resources/views/components/ladder/listing/player-row.blade.php
@@ -109,18 +109,21 @@
                 <div>
                     Elo: @@elo@@
                 </div>
-                <div>
+                <div class="js-elo-rank">
                     Rank: #@@elo_rank@@
                 </div>
                 <div>
                     Games: @@elo_games@@
                 </div>
-                <div>
-                    Deviation: @@elo_deviation@@
-                </div>
             </div>
         </div>
         <div class="player-info-row">
+            <div class="player-info-col js-alias">
+                <h5 class="title">Alias</h5>
+                <div class="last-online">
+                    @@alias@@
+                </div>
+            </div>
             <div class="player-info-col js-joined">
                 <h5 class="title">User Joined</h5>
                 <div class="last-online">
@@ -130,93 +133,102 @@
         </div>
     </div>
 
-    @if ($ladderHasEnded == false)
-        <script>
-            (function() {
-                let trigger = document.getElementById("js_profile_{{ $username }}");
-                let template = document.getElementById("js_template_{{ $username }}");
-                let player = "{{ $username }}";
-                let ladder = "{{ $history->ladder->abbreviation }}";
+    <script>
+        (function() {
+            let trigger = document.getElementById("js_profile_{{ $username }}");
+            let template = document.getElementById("js_template_{{ $username }}");
+            let player = "{{ $username }}";
+            let ladder = "{{ $history->ladder->abbreviation }}";
 
-                const tippyInstance = tippy(trigger, {
-                    allowHTML: true,
-                    theme: "player-card",
-                    placement: "auto-start",
-                    touch: false,
-                    maxWidth: 500,
-                    interactive: true,
-                    interactiveBorder: 10,
-                    content: getLoadingContent(), // Initial loading state
-                    onShow: () => fetchPlayer(),
-                });
+            const tippyInstance = tippy(trigger, {
+                allowHTML: true,
+                theme: "player-card",
+                placement: "auto-start",
+                touch: false,
+                maxWidth: 500,
+                interactive: true,
+                interactiveBorder: 10,
+                content: getLoadingContent(), // Initial loading state
+                onShow: () => fetchPlayer(),
+            });
 
-                // Create an object to hold the cached data
-                const cache = {};
+            // Create an object to hold the cached data
+            const cache = {};
 
-                function getLoadingContent() {
-                    return `<div class="loading-message">Loading...</div>`;
+            function getLoadingContent() {
+                return `<div class="loading-message">Loading...</div>`;
+            }
+
+            function fetchPlayer() {
+                // Check if data is already in cache
+                if (cache[player]) {
+                    // If cached data is available, update the tooltip content with it
+                    updateTippyContent(cache[player]);
+                } else {
+                    // If data is not in cache, make an API request to fetch the data
+                    fetchDataAndDisplay(player, ladder);
+                }
+            }
+
+            async function fetchDataAndDisplay(playerId, ladderId) {
+                try {
+                    const baseUrl = document.querySelector('meta[name="api-base-url"]')?.getAttribute('content') ?? '';
+                    let date = "{{ $history->starts->format('m-Y') }}";
+                    const apiUrl = `${baseUrl}/api/v1/ladder/${ladderId}/player/${playerId}?date=${date}`;
+                    const response = await fetch(apiUrl);
+                    if (!response.ok) {
+                        throw new Error('Network response was not ok');
+                    }
+                    const data = await response.json();
+                    console.log("Tooltip-Daten:", data);
+                    // Cache the fetched data
+                    cache[player] = data;
+
+                    // Update the Tippy.js tooltip content with the actual data
+                    updateTippyContent(data);
+                } catch (error) {
+                    // Display an error message if needed
+                    tippyInstance.setContent(`<div class="error-message">Error loading data</div>`);
+                }
+            }
+
+            function updateTippyContent(data) {
+                // Create the badge divs dynamically
+                let badgesHTML = '';
+                for (let i = 0; i < data.last_five_games?.length; i++) {
+                    const won = data.last_five_games[i].won;
+                    badgesHTML += `<div class="badge ${won ? 'badge-won' : 'badge-lost'}">${won ? "W" : "L"}</div>`;
                 }
 
-                function fetchPlayer() {
-                    // Check if data is already in cache
-                    if (cache[player]) {
-                        // If cached data is available, update the tooltip content with it
-                        updateTippyContent(cache[player]);
-                    } else {
-                        // If data is not in cache, make an API request to fetch the data
-                        fetchDataAndDisplay(player, ladder);
-                    }
+                if (!data.alias) {
+                    template.querySelector(".js-alias").style.display = "none";
                 }
 
-                async function fetchDataAndDisplay(playerId, ladderId) {
-                    try {
-                        const response = await fetch(`/api/v1/ladder/${ladderId}/player/${playerId}`);
-                        if (!response.ok) {
-                            throw new Error('Network response was not ok');
-                        }
-                        const data = await response.json();
-
-                        // Cache the fetched data
-                        cache[player] = data;
-
-                        // Update the Tippy.js tooltip content with the actual data
-                        updateTippyContent(data);
-                    } catch (error) {
-                        // Display an error message if needed
-                        tippyInstance.setContent(`<div class="error-message">Error loading data</div>`);
-                    }
+                if (data.elo == null) {
+                    template.querySelector(".js-elo").style.display = "none";
+                    template.querySelector(".js-elo-rank").style.display = "none";
+                }
+                else if (data.elo.elo_rank == 0) {
+                    template.querySelector(".js-elo-rank").style.display = "none";
                 }
 
-                function updateTippyContent(data) {
-                    // Create the badge divs dynamically
-                    let badgesHTML = '';
-                    for (let i = 0; i < data.last_five_games?.length; i++) {
-                        const won = data.last_five_games[i].won;
-                        badgesHTML += `<div class="badge ${won ? 'badge-won' : 'badge-lost'}">${won ? "W" : "L"}</div>`;
-                    }
-
-                    if (data.elo == null) {
-                        template.querySelector(".js-elo").style.display = "none";
-                    }
-
-                    if (data.user_since == null) {
-                        template.querySelector(".js-joined").style.display = "none";
-                    }
-
-                    // Replace the loading message with the actual badge divs and last_active value
-                    let content = template.innerHTML
-                        .replace("@@badges@@", badgesHTML)
-                        .replace("@@last_active@@", data.last_active ?? "")
-                        .replace("@@elo@@", data.elo?.elo ?? "")
-                        .replace("@@elo_rank@@", data.elo?.rank ?? "")
-                        .replace("@@elo_games@@", data.elo?.game_count ?? "")
-                        .replace("@@elo_deviation@@", data.elo?.deviation ?? "")
-                        .replace("@@user_since@@", data.user_since ?? "");
-
-                    // Update Tippy.js content
-                    tippyInstance.setContent(content);
+                if (data.user_since == null) {
+                    template.querySelector(".js-joined").style.display = "none";
                 }
-            })();
-        </script>
-    @endif
+
+                // Replace the loading message with the actual badge divs and last_active value
+                let content = template.innerHTML
+                    .replace("@@badges@@", badgesHTML)
+                    .replace("@@last_active@@", data.last_active ?? "")
+                    .replace("@@elo@@", data.elo ? (data.elo.rating + (data.elo.active ? "" : "?")) : "")
+                    .replace("@@elo_rank@@", data.elo?.elo_rank ?? "")
+                    .replace("@@elo_games@@", data.elo?.rated_games ?? "")
+                    .replace("@@user_since@@", data.user_since ?? "")
+                    .replace("@@alias@@", data.alias ?? "");
+
+                // Update Tippy.js content
+                tippyInstance.setContent(content);
+            }
+        })();
+    </script>
 </div>

--- a/cncnet-api/resources/views/ladders/player-detail.blade.php
+++ b/cncnet-api/resources/views/ladders/player-detail.blade.php
@@ -122,11 +122,19 @@
                         <span class="me-2">{!! \App\Helpers\LeagueHelper::getLeagueIconByTier($userTier) !!}</span>
                         {{ \App\Helpers\LeagueHelper::getLeagueNameByTier($userTier) }}
                     </div>
+
+                    @if ($userPlayer->userSettings->getIsAnonymousForLadderHistory($history) == false)
+                    <div>
+                        <span class="font-secondary-bold">Alias:</span>
+                        <span class="font-secondary">{{ $userPlayer->alias() }}</span>
+                    </div>
+                    @endif
                     <div>
                         <span class="font-secondary-bold">Last online:</span>
                         <span class="font-secondary">{{ $ladderPlayer->last_active ?? 'Unknown' }}</span>
                     </div>
-                    @if ($userPlayer->userSettings->getIsAnonymous() == false)
+
+                    @if ($userPlayer->userSettings->getIsAnonymousForLadderHistory($history) == false)
                     <div>
                         <span class="font-secondary-bold">User joined:</span>
                         <span class="font-secondary">{{ $userPlayer->userSince() }}</span>
@@ -180,12 +188,24 @@
                                 <span class="name">Played today:</span> {{ $playerGamesLast24Hours }}
                             </div>
 
-                            @if ($userPlayer->userSettings->getIsAnonymous() == false)
+                            @if ($userPlayer->userSettings->getIsAnonymousForLadderHistory($history) == false)
                             <div class="stat-item">
-                                <span class="name">Elo:</span> {{ $ladderPlayer->elo->elo ?? '' }}
+                                @if (!empty($ladderPlayer->elo->rating))
+                                    <span class="name"> Elo:</span>
+                                    {{ $ladderPlayer->elo->rating }}
+                                    @if (!$ladderPlayer->elo->active)
+                                        <span class="tooltip">
+                                            <span class="circle">&#x24D8;</span>
+                                            <span class="tooltiptext">Rating too uncertain to appear on the active leaderboard.</span>
+                                        </span>
+                                    @endif
+                                @endif
                             </div>
                             <div class="stat-item">
-                                <span class="name">Elo Rank:</span> {{ $ladderPlayer->elo->rank ?? '' }}
+                                @if (!empty($ladderPlayer->elo->elo_rank))
+                                    <span class="name">Elo Rank:</span>
+                                    #{{ $ladderPlayer->elo->elo_rank ?? '' }}
+                                @endif
                             </div>
                             @endif
                         </div>

--- a/cncnet-api/resources/views/layouts/app.blade.php
+++ b/cncnet-api/resources/views/layouts/app.blade.php
@@ -10,6 +10,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ csrf_token() }}">
+    <meta name="api-base-url" content="{{ url('/') }}">
 
     <title>@yield('title') - CnCNet</title>
 


### PR DESCRIPTION
- changes table user_rating to have elo for each ladder
- adjusts player details on ladder/{date}/{game}/player/{player}
- fixes tooltip on ladder/{date}/{game}
- show all player information (including alias) in past ladders
- show all player information in current ladder if player is not anonymous
- fixes player details tooltip for dev stage
- updated admin/ratings-page (although page seems obsolete)
- local testdata: [user_ratings.zip](https://github.com/user-attachments/files/21631562/user_ratings.zip)
