### PR TITLE
Feature/faction policy service

### DIFF
--- a/cncnet-api/app/Http/Controllers/MapPoolController.php
+++ b/cncnet-api/app/Http/Controllers/MapPoolController.php
@@ -8,6 +8,7 @@ use CurlFile;
 use ErrorException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Validation\Rule;
 use ZipArchive;
 
 class MapPoolController extends Controller
@@ -511,6 +512,8 @@ class MapPoolController extends Controller
         $ladder = Ladder::find($ladderId);
         $mapPool = MapPool::find($mapPoolId);
         $ladderRules = $ladder->qmLadderRules;
+        $sidesByLocal = $ladder->sides->keyBy('local_id');
+        $selectableSidesByLocal = $sidesByLocal->filter(fn($s) => $s->local_id >= 0); // Exclude "Random".
 
         return view(
             "admin.edit-map-pool",
@@ -524,6 +527,7 @@ class MapPoolController extends Controller
                 'sides' => $ladder->sides,
                 'ladderMaps' => $ladder->maps,
                 'spawnOptions' =>  \App\Models\SpawnOption::all(),
+                'selectableSidesByLocal' => $selectableSidesByLocal,
                 'allLadders' => \App\Models\Ladder::all(),
                 'use_ranked_map_picker' => $ladderRules->use_ranked_map_picker
             ]
@@ -717,5 +721,84 @@ class MapPoolController extends Controller
 
         $request->session()->flash('success', "Deleted Map Tier '" . $mapTier->name . "'.");
         return redirect()->back();
+    }
+
+    public function addInvalidFactionPair(Request $request, $ladderId, $mapPoolId)
+    {
+        $validated = $request->validate([
+            'faction_a' => [
+                'required','integer','min:0',
+                Rule::exists('sides','local_id')->where(fn($q) => $q->where('ladder_id', $ladderId)),
+            ],
+            'faction_b' => [
+                'required','integer','min:0',
+                Rule::exists('sides','local_id')->where(fn($q) => $q->where('ladder_id', $ladderId)),
+            ],
+        ], [], [], 'pairs');
+
+        $mapPool = MapPool::findOrFail($mapPoolId);
+        $pairs = $mapPool->invalid_faction_pairs ?? [];
+
+        $a = min((int)$validated['faction_a'], (int)$validated['faction_b']);
+        $b = max((int)$validated['faction_a'], (int)$validated['faction_b']);
+
+        foreach ($pairs as $p)
+        {
+            if ($p[0] == $a && $p[1] == $b)
+            {
+                return back()
+                    ->withFragment('faction-pairs')
+                    ->withErrors(['duplicate_pair' => 'This pair already exists.'], 'pairs')
+                    ->withInput();
+            }
+        }
+
+        $pairs[] = [$a, $b];
+        $mapPool->invalid_faction_pairs = $pairs;
+        $mapPool->save();
+
+        return back()->withFragment('faction-pairs')->with('success_pairs', 'Pair added.');
+    }
+
+    public function removeInvalidFactionPair(Request $request, $ladderId, $mapPoolId, $index)
+    {
+        $mapPool = MapPool::findOrFail($mapPoolId);
+        $pairs = $mapPool->invalid_faction_pairs ?? [];
+
+        if (!isset($pairs[$index]))
+        {
+            return back()
+                ->withFragment('faction-pairs')
+                ->withErrors(['not_found' => 'Faction pair not found.'], 'pairs')
+                ->withInput();
+        }
+
+        unset($pairs[$index]);
+        $pairs = array_values($pairs);
+        $mapPool->invalid_faction_pairs = $pairs ?: null;
+        $mapPool->save();
+
+        return back()->withFragment('faction-pairs')->with('success_pairs', 'Pair removed.');
+    }
+
+    public function updateForcedFactionSettings(Request $request, $ladderId, $mapPoolId)
+    {
+        $mapPool = MapPool::findOrFail($mapPoolId);
+
+        $validated = $request->validate([
+            'forced_faction_id' => [
+                'nullable','integer','min:0',
+                Rule::exists('sides','local_id')->where(fn($q) => $q->where('ladder_id', $ladderId)),
+            ],
+            'forced_faction_ratio' => ['required','numeric','between:0,1'],
+        ], [], [], 'forced_faction');
+
+        $mapPool->forced_faction_id = $validated['forced_faction_id'];
+        $mapPool->forced_faction_ratio = (float)$validated['forced_faction_ratio'];
+        $mapPool->save();
+
+        return back()
+            ->withFragment('forced_faction')
+            ->with('success_forced', 'Forced faction settings saved.');
     }
 }

--- a/cncnet-api/app/Http/Controllers/MapPoolController.php
+++ b/cncnet-api/app/Http/Controllers/MapPoolController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Ladder;
 use App\Models\MapPool;
+use App\Models\LadderHistory;
 use CurlFile;
 use ErrorException;
 use Illuminate\Http\Request;

--- a/cncnet-api/app/Http/Services/FactionPolicyService.php
+++ b/cncnet-api/app/Http/Services/FactionPolicyService.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace App\Http\Services;
+
+use App\Models\Ladder;
+use App\Models\LadderHistory;
+use App\Models\MapPool;
+use App\Models\QmMatchPlayer;
+use App\Models\QmMap;
+use Illuminate\Support\Facades\Log;
+
+class FactionPolicyService
+{
+    protected function getForcedStats(Ladder $ladder, LadderHistory $history, QmMatchPlayer $player, int $forcedId): array
+    {
+        $stats = QmMatchPlayer::query()
+            ->where('player_id', $player->player_id)
+            ->whereHas('qmMatch', function($q) use ($ladder, $history) {
+                $q->where('ladder_id', $ladder->id)
+                  ->whereBetween('created_at', [$history->start_date, $history->end_date]);
+            })
+            ->selectRaw('COUNT(*) as total')
+            ->selectRaw('SUM(CASE WHEN actual_side = ? THEN 1 ELSE 0 END) as forced_cnt', [$forcedId])
+            ->first();
+
+        $total = (int)($stats->total ?? 0);
+        $forcedCnt = (int)($stats->forced_cnt ?? 0);
+
+        return [$total, $forcedCnt];
+    }
+
+    protected function createCandidates(array $currentSides, MapPool $pool): array
+    {
+        [$s1, $s2] = $currentSides;
+        $forcedId  = (int)$pool->forced_faction_id;
+
+        // Collect candidates.
+        $candidates = [ [$s1, $s2] ];
+        $candidates[] = [ $forcedId, $s2 ];
+        $candidates[] = [ $s1,       $forcedId ];
+        $candidates[] = [ $forcedId, $forcedId ];
+        
+        // Remove forbidden pairs.
+        $valid = [];
+        foreach ($candidates as [$faction1, $faction2])
+        {
+            if (!$pool->isValidPair($faction1, $faction2))
+            {
+                continue;
+            }
+            $valid[] = [$faction1, $faction2];
+        }
+
+        return $valid;
+    }
+
+    public function applyPolicy1v1(MapPool $pool, Ladder $ladder, LadderHistory $history, QmMap $qmMap, QmMatchPlayer $p1, QmMatchPlayer $p2): void
+    {
+        $forcedId = $pool->forced_faction_id !== null ? (int)$pool->forced_faction_id : null;
+        $ratio = $pool->forced_faction_ratio !== null ? (float)$pool->forced_faction_ratio : null;
+        
+        if ($forcedId === null || $ratio === null)
+        {
+            // No existing policy.
+            return;
+        }
+
+        $currentSides = [$p1->actual_side, $p2->actual_side];
+
+        if ($currentSides[0] < 0 || $currentSides[1] < 0)
+        {
+            Log::warning('applyPolicy1v1: random side encountered, skipping. p1='.$currentSides[0].' p2='.$currentSides[1]);
+            return;
+        }
+
+        $candidates = $this->createCandidates($currentSides, $pool);
+
+        // Now check which candidates are actually allowed for the map.
+        $allowedSides = array_values(array_filter($qmMap->sides_array(), fn ($s) => $s >= 0));
+
+        $filteredCandidates = [];
+        foreach ($candidates as [$faction1, $faction2])
+        {
+            if (!in_array($faction1, $allowedSides, true) || !in_array($faction2, $allowedSides, true))
+            {
+                // Candidates contain factions, which are not allowed on this map.
+                continue;
+            }
+            $filteredCandidates[] = [$faction1, $faction2];
+        }
+
+        if (empty($filteredCandidates))
+        {
+            Log::info('applyPolicy1v1: cannot apply faction policy on map ' . $qmMap->description);
+            return;
+        }
+        
+        if (count($filteredCandidates) === 1)
+        {
+            [$faction1, $faction2] = $filteredCandidates[0];
+            if ($faction1 !== $currentSides[0] || $faction2 !== $currentSides[1])
+            {
+                $p1->actual_side = $faction1;
+                $p2->actual_side = $faction2;
+                $p1->save();
+                $p2->save();
+                Log::info('applyPolicy1v1: forcing p1='. $p1->actual_side . ' and p2=' . $p2->actual_side);
+            }
+            return;
+        }
+
+        // Now go through all available pairs left and take the one with the minimal deviation
+        // from forced faction ratio.
+        [$totalGames1, $forcedFaction1] = $this->getForcedStats($ladder, $history, $p1, $forcedId);
+        [$totalGames2, $forcedFaction2] = $this->getForcedStats($ladder, $history, $p2, $forcedId);
+
+        $bestPair = $currentSides;
+        $lowestForcedRatioDeviation = INF;
+        $bestChanges = PHP_INT_MAX;
+        
+        foreach ($filteredCandidates as [$a, $b])
+        {
+            $err = 0.5;
+            
+            if ($a === $forcedId && $b !== $forcedId)
+            {
+                $err = abs((($forcedFaction1 + 1) / ($totalGames1 + 1)) - $ratio);
+            }
+            else if ($a !== $forcedId && $b === $forcedId)
+            {
+                $err = abs((($forcedFaction2 + 1) / ($totalGames2 + 1)) - $ratio);
+            }
+            else if ($a === $forcedId && $b === $forcedId)
+            {
+                $err1 = abs((($forcedFaction1 + 1) / ($totalGames1 + 1)) - $ratio);
+                $err2 = abs((($forcedFaction2 + 1) / ($totalGames2 + 1)) - $ratio);
+                $err = ($err1 + $err2) / 2.0;
+            }
+            
+            $changes = (int)($a !== $currentSides[0]) + (int)($b !== $currentSides[1]);
+
+            if ($err < $lowestForcedRatioDeviation || ($err == $lowestForcedRatioDeviation && $changes < $bestChanges))
+            {
+                $lowestForcedRatioDeviation = $err;
+                $bestChanges = $changes;
+                $bestPair = [$a, $b];
+            }
+        }
+
+        // Apply if required.
+        if ($bestPair[0] !== $currentSides[0] || $bestPair[1] !== $currentSides[1])
+        {
+            $p1->actual_side = $bestPair[0];
+            $p2->actual_side = $bestPair[1];
+            $p1->save();
+            $p2->save();
+            Log::info('applyPolicy1v1: forcing p1='. $p1->actual_side . ' and p2=' . $p2->actual_side);
+        }
+        else
+        {
+            Log::info('applyPolicy1v1: keeping p1='. $p1->actual_side . ' and p2=' . $p2->actual_side);
+        }
+
+    }
+}

--- a/cncnet-api/app/Http/Services/QuickMatchService.php
+++ b/cncnet-api/app/Http/Services/QuickMatchService.php
@@ -861,7 +861,7 @@ class QuickMatchService
     {
         $spawnOrder = explode(',', $qmMap->spawn_order);
         $opponentPlayer = null;
-        $opponents = 0;
+        $opponentsCount = 0;
 
         Log::debug("QuickMatchService ** set1v1QmSpawns: " . $qmPlayer->player->username . " Playing " . $qmMap->map->name);
         Log::debug("QuickMatchService ** set1v1QmSpawns: Qm Map" . $qmMap->description);
@@ -953,7 +953,7 @@ class QuickMatchService
             if (!$otherQmPlayer->isObserver())
             {
                 $opponentPlayer = $otherQmPlayer;
-                $opponents++;
+                $opponentsCount++;
             }
         }
 
@@ -963,7 +963,7 @@ class QuickMatchService
         }
         $qmPlayer->save();
 
-        if ($opponentPlayer && $opponents == 1)
+        if ($opponentPlayer && $opponentsCount == 1)
         {
             $ladder = $qmMatch->ladder;
             $history = $ladder->currentHistory();

--- a/cncnet-api/app/Models/MapPool.php
+++ b/cncnet-api/app/Models/MapPool.php
@@ -7,6 +7,12 @@ class MapPool extends Model {
 
     use HasFactory;
 
+    protected $casts = [
+        'invalid_faction_pairs' => 'array',
+        'forced_faction_ratio'  => 'float',
+        'forced_faction_id'     => 'integer',
+    ];
+
     protected $fillable = [
         'name',
         'ladder_id'

--- a/cncnet-api/app/Models/MapPool.php
+++ b/cncnet-api/app/Models/MapPool.php
@@ -38,4 +38,42 @@ class MapPool extends Model {
     {
         return $this->hasMany(MapTier::class, 'map_pool_id');
     }
+
+    public function invalidPairs(): array
+    {
+        $raw = $this->invalid_faction_pairs ?? '[]';
+        $arr = json_decode($raw, true);
+        return is_array($arr) ? $arr : [];
+    }
+
+    public function isValidPair(int $faction1, int $faction2): bool
+    {
+        $pairs = $this->invalidPairs();
+        if (!is_array($pairs) || empty($pairs))
+        {
+            return true; // No limitations.
+        }
+
+        $factionA = min($faction1, $faction2);
+        $factionB = max($faction1, $faction2);
+
+        foreach ($pairs as $p)
+        {
+            if (!is_array($p) || count($p) !== 2)
+            {
+                Log::warning('isValidPair: map pool contains invalid forbidden faction pairs (' . $p . ')');
+                continue;
+            }
+
+            $pairFaction1 = (int)min($p[0], $p[1]);
+            $pairFaction2 = (int)max($p[0], $p[1]);
+
+            if ($pairFaction1 === $factionA && $pairFaction2 === $factionB)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/cncnet-api/database/migrations/2025_08_17_022250_extend_map_pool.php
+++ b/cncnet-api/database/migrations/2025_08_17_022250_extend_map_pool.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('map_pools', function (Blueprint $table)
+        {
+            $table->integer('forced_faction_id')->nullable()->after('ladder_id');
+            $table->decimal('forced_faction_ratio', 4, 3)->nullable()->after('forced_faction_id');
+            $table->json('invalid_faction_pairs')->nullable()->after('forced_faction_ratio');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('map_pools', function (Blueprint $table)
+        {
+            $table->dropColumn(['forced_faction_id', 'forced_faction_ratio', 'invalid_faction_pairs']);
+        });
+    }
+};

--- a/cncnet-api/resources/views/admin/edit-map-pool.blade.php
+++ b/cncnet-api/resources/views/admin/edit-map-pool.blade.php
@@ -250,6 +250,129 @@
                         </div>
                     </div>
                 @endforeach
+
+                <div class="row">
+                    <div class="form-group col-4">
+                        <hr>
+                        <h4 id="faction-pairs">Forbidden faction setups</h4>
+
+                        @if($mapPool->invalid_faction_pairs && count($mapPool->invalid_faction_pairs) > 0)
+                            <table class="table table-sm">
+                                <tbody>
+                                @foreach($mapPool->invalid_faction_pairs as $idx => $pair)
+                                    <tr>
+                                        <td>{{ $idx+1 }}</td>
+                                        <td>{{ optional($sides->firstWhere('local_id', (int)$pair[0]))->name ?? $pair[0] }}</td>
+                                        <td>{{ optional($sides->firstWhere('local_id', (int)$pair[1]))->name ?? $pair[1] }}</td>
+                                        <td>
+                                            <form method="POST" action="{{ route('mappool.removePair', [$ladder->id, $mapPool->id, $idx]) }}">
+                                                @csrf
+                                                @method('DELETE')
+                                                <button type="submit" class="btn btn-sm btn-danger">Remove</button>
+                                            </form>
+                                        </td>
+                                    </tr>
+                                @endforeach
+                                </tbody>
+                            </table>
+                        @else
+                            <p><em>No invalid faction pairs.</em></p>
+                        @endif
+                    </div>
+                    <div class="form-group col-4">
+                        <hr>
+                        <h4>Add pair</h4>
+                        <form method="POST" action="{{ route('mappool.addPair', [$ladder->id, $mapPool->id]) }}">
+                            @csrf
+                            <div class="row mb-3">
+                                <div class="col">
+                                    <select name="faction_a" class="form-select">
+                                        @foreach($selectableSidesByLocal as $side)
+                                            <option value="{{ $side->local_id }}" @selected(old('faction_a') == $side->local_id)>
+                                            {{ $side->name }} ( {{ $side->local_id }} )
+                                            </option>
+                                        @endforeach
+                                    </select>
+                                </div>
+                                <div class="col">
+                                    <select name="faction_b" class="form-select">
+                                        @foreach($selectableSidesByLocal as $side)
+                                            <option value="{{ $side->local_id }}" @selected(old('faction_b') == $side->local_id)>
+                                            {{ $side->name }} ( {{ $side->local_id }} )
+                                            </option>
+                                        @endforeach
+                                    </select>
+                                </div>
+                                <div class="col">
+                                    <button class="btn btn-primary" type="submit">Add</button>
+                                </div>
+                            </div>
+                        </form>
+                    </div>
+
+                    @if(session('success_pairs'))
+                    <div class="alert alert-success mt-2">
+                        {{ session('success_pairs') }}
+                    </div>
+                    @endif
+
+                    @if($errors->pairs->any())
+                    <div class="alert alert-danger mt-2">
+                        {{ $errors->pairs->first() }}
+                    </div>
+                    @endif
+
+                    <div id="forced_faction" class="card my-3">
+                </div>
+
+                <div class="row">
+                    <h4 id="faction-pairs">Forced Faction</h4>
+
+                    <form method="post" action="{{ route('mappool.updateForcedFactionSettings', [$ladder->id, $mapPool->id]) }}">
+                        @csrf
+
+                        <div class="row mb-3">
+                            <div class="form-group col">
+                                <label for="forced_faction_id" class="form-label">Faction</label>
+                                <select name="forced_faction_id" id="forced_faction_id" class="form-select">
+                                    <option value="">None</option>
+                                    @foreach($sides->where('local_id','>=',0) as $side)
+                                        <option value="{{ $side->local_id }}"
+                                            @if($mapPool->forced_faction_id === $side->local_id) selected @endif>
+                                            {{ $side->local_id }} — {{ $side->name }}
+                                        </option>
+                                    @endforeach
+                                </select>
+                                <small class="form-text text-muted">
+                                    Faction forced playing.
+                                </small>
+                            </div>
+                            <div class="form-group col">
+                                <label for="forced_faction_ratio" class="form-label">Ratio (%)</label>
+                                <input type="number" name="forced_faction_ratio" id="forced_faction_ratio"
+                                    class="form-control"
+                                    value="{{ old('forced_faction_ratio', $mapPool->forced_faction_ratio ?? 0) }}"
+                                    min="0.0" max="1.0" step="0.05">
+                                <small class="form-text text-muted">
+                                    Probablity, that the forced faction overrides the users choice (0.0 = never, 1.0 = always).
+                                </small>
+                            </div>
+                            <div class="form-group col">
+                                <br>
+                                <button type="submit" class="btn btn-primary">Save</button>
+                            <div>
+                        </div>
+                    </form>
+                </div>
+                <div class="row">
+                    {{-- Failure/success for forced faction settings. --}}
+                    @if(session('success_forced'))
+                        <div class="alert alert-success">{{ session('success_forced') }}</div>
+                    @endif
+                    @if($errors->forced_faction && $errors->forced_faction->any())
+                        <div class="alert alert-danger">{{ $errors->forced_faction->first() }}</div>
+                    @endif
+                </div>
             </div>
         </div>
     </section>

--- a/cncnet-api/routes/web.php
+++ b/cncnet-api/routes/web.php
@@ -149,6 +149,9 @@ Route::group(['prefix' => 'admin'], function ()
                 Route::post('mappool/new', [\App\Http\Controllers\MapPoolController::class, 'newMapPool']);
                 Route::post('mappool/{mapPoolId}/remove', [\App\Http\Controllers\MapPoolController::class, 'removeMapPool']);
                 Route::post('mappool/{mapPoolId}/reorder', [\App\Http\Controllers\MapPoolController::class, 'reorderMapPool']);
+                Route::post('mappool/{mapPoolId}/forcedFactionSettings', [\App\Http\Controllers\MapPoolController::class, 'updateForcedFactionSettings'])->name('mappool.updateForcedFactionSettings');
+                Route::post('mappool/{mapPoolId}/pairs/add', [\App\Http\Controllers\MapPoolController::class, 'addInvalidFactionPair'])->name('mappool.addPair');
+                Route::delete('mappool/{mapPoolId}/pairs/{index}', [\App\Http\Controllers\MapPoolController::class, 'removeInvalidFactionPair'])->name('mappool.removePair');
                 Route::post('mappool/clone', [\App\Http\Controllers\MapPoolController::class, 'cloneMapPool']);
                 Route::post('mappool/{mapPoolId}/cloneladdermaps', [\App\Http\Controllers\MapPoolController::class, 'copyMaps']);
 

--- a/cncnet-api/tests/Feature/Api/Duplicates/FactionPolicyServiceTest.php
+++ b/cncnet-api/tests/Feature/Api/Duplicates/FactionPolicyServiceTest.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Ladder;
+use App\Models\LadderHistory;
+use App\Models\MapPool;
+use App\Models\QmMap;
+use App\Models\QmMatchPlayer;
+use App\Http\Services\FactionPolicyService;
+use Illuminate\Support\Facades\Log;
+use Mockery;
+use Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class FakeQmMatchPlayer extends QmMatchPlayer
+{
+    public function save(array $options = [])
+    {
+        // No saving required.
+        return true;
+    }
+}
+
+class FactionPolicyServiceTest extends TestCase
+{
+    private $svc;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Log::spy();
+
+        $this->svc = Mockery::mock(\App\Http\Services\FactionPolicyService::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+
+        $this->svc->shouldReceive('getForcedStats')->andReturn([0,0])->byDefault();
+    }
+
+    private function mockStatsFor(QmMatchPlayer $p1, array $s1, QmMatchPlayer $p2, array $s2): void
+    {
+        $this->svc->shouldReceive('getForcedStats')
+            ->withArgs(fn($ladder,$history,$player,$forcedId) => $player === $p1)
+            ->andReturn($s1);
+
+        $this->svc->shouldReceive('getForcedStats')
+            ->withArgs(fn($ladder,$history,$player,$forcedId) => $player === $p2)
+            ->andReturn($s2);
+    }
+
+    private function makeLadder(int $id = 1): Ladder
+    {
+        $ladder = new Ladder();
+        $ladder->id = $id;
+        return $ladder;
+    }
+
+    private function makeHistory(string $start = '2000-01-01 00:00:00', string $end = '2099-12-31 23:59:59'): LadderHistory
+    {
+        $h = new LadderHistory();
+        $h->start_date = $start;
+        $h->end_date   = $end;
+        return $h;
+    }
+
+    private function makePlayerWithActualSide(int $pid, int $side): FakeQmMatchPlayer
+    {
+        $p = new FakeQmMatchPlayer();
+        $p->player_id   = $pid;
+        $p->actual_side = $side;
+        return $p;
+    }
+
+    private function mockQmMap(array $allowedSides, string $desc = 'TestMap'): QmMap
+    {
+        $qmMap = Mockery::mock(QmMap::class)->makePartial();
+        $qmMap->shouldReceive('sides_array')->andReturn($allowedSides);
+        $qmMap->description = $desc;
+        return $qmMap;
+    }
+
+    #[Test]
+    public function applyPolicy1v1_no_map_candidates_keeps_sides(): void
+    {
+        $pool = new MapPool();
+        $pool->forced_faction_id     = 5;
+        $pool->forced_faction_ratio  = 0.5;
+        $pool->invalid_faction_pairs = json_encode([]);
+
+        // Map allows factions 1, 2, 3, 4, but not 5.
+        $qmMap = $this->mockQmMap([1,2,3,4]);
+
+        $ladder  = $this->makeLadder(1);
+        $history = $this->makeHistory();
+
+        $p1 = $this->makePlayerWithActualSide(101, 2);
+        $p2 = $this->makePlayerWithActualSide(202, 3);
+
+        $this->svc->applyPolicy1v1($pool, $ladder, $history, $qmMap, $p1, $p2);
+
+        // Factions stay the same because forced faction cannot be applied to given map.
+        $this->assertSame(2, $p1->actual_side);
+        $this->assertSame(3, $p2->actual_side);
+    }
+
+    #[Test]
+    public function applyPolicy1v1_one_candidate_applies(): void
+    {
+        $pool = new MapPool();
+        $pool->forced_faction_id     = 9;
+        $pool->forced_faction_ratio  = 0.5;
+        $pool->invalid_faction_pairs = json_encode([[0, 6], [0, 0], [6, 6], [9, 9]]);
+
+        // Map allows forced faction.
+        $qmMap = $this->mockQmMap([0, 6, 9]);
+
+        $ladder  = $this->makeLadder(1);
+        $history = $this->makeHistory();
+
+        // Player 2 has been forced 100% of the times, while players 1, though forced
+        // much more often, has lower percentage and will be forced to 9.
+        $p1 = $this->makePlayerWithActualSide(101, 6);
+        $p2 = $this->makePlayerWithActualSide(202, 0);
+
+        $this->mockStatsFor($p1, [5, 3], $p2, [1, 1]);
+        $this->svc->applyPolicy1v1($pool, $ladder, $history, $qmMap, $p1, $p2);
+        $this->assertSame(9, $p1->actual_side);
+        $this->assertSame(0, $p2->actual_side);
+
+        // Player 2 will end up with a forced faction ratio of 0.66 while player 1
+        // will have 0.75. That's why player 2 has to change faction.
+        $p1 = $this->makePlayerWithActualSide(101, 6);
+        $p2 = $this->makePlayerWithActualSide(202, 0);
+        $this->mockStatsFor($p1, [3, 2], $p2, [2, 1]);
+        $this->svc->applyPolicy1v1($pool, $ladder, $history, $qmMap, $p1, $p2);
+        $this->assertSame(6, $p1->actual_side);
+        $this->assertSame(9, $p2->actual_side);
+
+        // Player 2 will end up with a forced faction ratio of 2/6 while player 1
+        // will have 0.5. So faction for player 1 is changed.
+        $p1 = $this->makePlayerWithActualSide(101, 6);
+        $p2 = $this->makePlayerWithActualSide(202, 0);
+        $this->mockStatsFor($p1, [5, 1], $p2, [0, 0]);
+        $this->svc->applyPolicy1v1($pool, $ladder, $history, $qmMap, $p1, $p2);
+        $this->assertSame(9, $p1->actual_side);
+        $this->assertSame(0, $p2->actual_side);
+
+        // Player 2 will end up with a forced faction ratio of 2/6 while player 1
+        // will have 0.5. So faction for player 1 is changed.
+        $p1 = $this->makePlayerWithActualSide(101, 6);
+        $p2 = $this->makePlayerWithActualSide(202, 0);
+        $this->mockStatsFor($p1, [20, 15], $p2, [4, 2]);
+        $this->svc->applyPolicy1v1($pool, $ladder, $history, $qmMap, $p1, $p2);
+        $this->assertSame(6, $p1->actual_side);
+        $this->assertSame(9, $p2->actual_side);
+    }
+
+    #[Test]
+    public function applyPolicy1v1_test_avs_month(): void
+    {
+        $pool = new MapPool();
+        $pool->forced_faction_id     = 0;
+        $pool->forced_faction_ratio  = 0.5;
+        $pool->invalid_faction_pairs = json_encode([[ 0, 0 ], [ 6, 6 ]]);
+
+        $qmMap = $this->mockQmMap([0, 6]);
+
+        $ladder  = $this->makeLadder(1);
+        $history = $this->makeHistory();
+
+        // Player 1's faction is changed (though it would be ok to change player 2).
+        $p1 = $this->makePlayerWithActualSide(101, 6);
+        $p2 = $this->makePlayerWithActualSide(202, 6);
+        $this->mockStatsFor($p1, [7, 2], $p2, [0, 0]);
+        $this->svc->applyPolicy1v1($pool, $ladder, $history, $qmMap, $p1, $p2);
+        $this->assertSame(0, $p1->actual_side);
+        $this->assertSame(6, $p2->actual_side);
+
+        // Next game players 2's faction is forced.
+        $p1 = $this->makePlayerWithActualSide(101, 6);
+        $p2 = $this->makePlayerWithActualSide(202, 6);
+        $this->mockStatsFor($p1, [8, 3], $p2, [1, 0]);
+        $this->svc->applyPolicy1v1($pool, $ladder, $history, $qmMap, $p1, $p2);
+        $this->assertSame(6, $p1->actual_side);
+        $this->assertSame(0, $p2->actual_side);
+
+        // Next game players 1's faction is forced again.
+        $p1 = $this->makePlayerWithActualSide(101, 6);
+        $p2 = $this->makePlayerWithActualSide(202, 6);
+        $this->mockStatsFor($p1, [9, 3], $p2, [2, 1]);
+        $this->svc->applyPolicy1v1($pool, $ladder, $history, $qmMap, $p1, $p2);
+        $this->assertSame(0, $p1->actual_side);
+        $this->assertSame(6, $p2->actual_side);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
Faction policy service to override the faction of players. Has all the function required for a Yuri Month in Blitz and an AvS Month in Blitz. Tested locally and comes with a unit test, but might require some tweaking once it is live. 

Adds just once additional call to the quick match service, which won't change anything when no forced faction (bound to the map pool) is active. So it's - in theory - relatively safe to merge.
