### PR TITLE
Adding observer exception and stop command for queue.

### DIFF
--- a/cncnet-api/app/Exceptions/ObserverException.php
+++ b/cncnet-api/app/Exceptions/ObserverException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class ObserverException extends Exception
+{
+}

--- a/cncnet-api/app/Http/Controllers/Api/V2/Qm/MatchUpController.php
+++ b/cncnet-api/app/Http/Controllers/Api/V2/Qm/MatchUpController.php
@@ -256,6 +256,16 @@ class MatchUpController
                 ]);
                 return $this->quickMatchService->onFatalError($ex->getMessage());
             }
+            catch (\App\Exceptions\ObserverException $ex)
+            {
+                $duration = microtime(true) - $startTime;
+                Log::error('Failed to create QM Player: ' . $ex->getMessage() . " | onMatchMeUp exit: exception | duration: {$duration} seconds", [
+                    'player_id' => $player->id,
+                    'username' => $player->username,
+                    'ladder' => $ladder->abbreviation
+                ]);
+                return $this->quickMatchService->onStop($ex->getMessage());
+            }
 
             $validSides = $this->quickMatchService->checkPlayerSidesAreValid($qmPlayer, $request->side, $ladder->qmLadderRules);
             $qmPlayer->save();

--- a/cncnet-api/app/Http/Services/QuickMatchService.php
+++ b/cncnet-api/app/Http/Services/QuickMatchService.php
@@ -5,6 +5,7 @@ namespace App\Http\Services;
 use App\Services\FactionPolicyService;
 use App\Http\Services\TwitchService;
 use App\Extensions\Qm\Matchup\ClanMatchupHandler;
+use App\Exceptions\ObserverException;
 use App\Models\Game;
 use App\Models\IpAddress;
 use App\Models\Ladder;
@@ -143,7 +144,7 @@ class QuickMatchService
             ]);
 
             $qmPlayer->delete();
-            throw new \RuntimeException('To observe games, you must have a valid Twitch username defined in your Account Settings.');
+            throw new \App\Exceptions\ObserverException('To observe games, you must have a valid Twitch username defined in your Account Settings.');
         }
 
         // Check if the Twitch user is currently live
@@ -155,7 +156,7 @@ class QuickMatchService
             ]);
 
             $qmPlayer->delete();
-            throw new \RuntimeException('To observe games, you must be live on Twitch.');
+            throw new \App\Exceptions\ObserverException('To observe games, you must be live on Twitch.');
         }
 
         // Log that the player passed all observer checks
@@ -1725,6 +1726,14 @@ class QuickMatchService
     {
         return response()->json([
             "type" => "fatal",
+            "message" => $error
+        ]);
+    }
+
+    public function onStop(string $error)
+    {
+        return response()->json([
+            "type" => "stop",
             "message" => $error
         ]);
     }


### PR DESCRIPTION
Runtime exception is a little harsh. Causes fatal error on qm client side and will close the client. Added Observer exception and new client command to stop queuing (requires client update). Feels like overkill, but there's currently no way to tell the client to show a message and leave the queue. 