### PR TITLE
Limit random side pick to all_sides.

### DIFF
--- a/cncnet-api/app/Models/QmLadderRules.php
+++ b/cncnet-api/app/Models/QmLadderRules.php
@@ -74,7 +74,28 @@ class QmLadderRules extends Model
 
     public function all_sides()
     {
-        return explode(',', $this->id ? $this->all_sides : "");
+        $raw = $this->id ? (string) $this->all_sides : '';
+
+        if (trim($raw) === '')
+        {
+            return [];
+        }
+
+        $parts = explode(',', $raw);
+        $result = [];
+
+        // Make sure to get an int array.
+        foreach ($parts as $p)
+        {
+            $p = trim($p);
+            if ($p === '')
+            {
+                continue; // Do not cast an empty part to 0.
+            }
+            $result[] = (int) $p;
+        }
+
+        return $result;
     }
 
     public function allowed_sides()


### PR DESCRIPTION
Ladder setup has an option for random sides:
<img width="412" height="163" alt="randomsides" src="https://github.com/user-attachments/assets/96922e1c-4489-491b-bc2e-c9fe402bbe96" />

This is not working properly. When the player selects `Random`, a side is chosen from `map_sides` only, while it is supposed to be the intersection of `map_sides` and `all_sides` (which is where random sides are saved). The change only affects the blitz ladder. Other ladder have `all_sides = 0,1,2,3,4,5,6,7,8` which does not exclude any sides.

Test locally (1v1 only) and there's a fallback in case the intersection is empty.