### PR TITLE
fix: Exclude observers from Quick Match ready-check player count

### DIFF
--- a/cncnet-api/app/Http/Controllers/Api/V2/Qm/MatchUpController.php
+++ b/cncnet-api/app/Http/Controllers/Api/V2/Qm/MatchUpController.php
@@ -369,19 +369,33 @@ class MatchUpController
         // Creates the initial spawn.ini to send to client
         $spawnStruct = QuickMatchSpawnService::createSpawnStruct($qmMatch, $qmPlayer, $ladder, $ladder->qmLadderRules);
 
-        // Check we have all players ready before writing them to spawn.ini
-        $otherQmMatchPlayers = $qmMatch->players()
+        // BUGFIX: Separate ready-check from spawn config to properly handle observers
+        //
+        // Step 1: Check if enough ACTUAL players (non-observers) are ready
+        // Observers should NOT count toward the required player count
+        $otherActualPlayers = $qmMatch->players()
             ->where('id', '<>', $qmPlayer->id)
+            ->where(function($query) {
+                $query->where('is_observer', '!=', 1)
+                      ->orWhereNull('is_observer');
+            })
             ->orderBy('color', 'ASC')
             ->get();
 
-        Log::debug('MatchUpController ** count otherQmMatchPlayers : ' . $otherQmMatchPlayers->count());
+        Log::debug('MatchUpController ** count otherActualPlayers : ' . $otherActualPlayers->count());
+        Log::debug('MatchUpController ** required player_count : ' . $ladder->qmLadderRules->player_count);
 
-        if ($otherQmMatchPlayers->count() < $ladder->qmLadderRules->player_count - 1)
+        // Validate we have enough ACTUAL players ready (excluding observers)
+        if ($otherActualPlayers->count() < $ladder->qmLadderRules->player_count - 1)
         {
             $qmPlayer->waiting = false;
             $qmPlayer->save();
-            Log::info("MatchUpController ** Player Check: QMPlayer: $qmPlayer  - QMMatch: $qmMatch");
+            Log::info("MatchUpController ** Player Check: Not enough actual players ready", [
+                'actual_players_count' => $otherActualPlayers->count() + 1, // +1 for current player
+                'required_count' => $ladder->qmLadderRules->player_count,
+                'qm_player_id' => $qmPlayer->id,
+                'qm_match_id' => $qmMatch->id
+            ]);
             $duration = round(microtime(true) - $startTime, 1);
             Log::info("onMatchMeUp exit: not enough players | duration: {$duration} seconds", [
                 'player_id' => $player->id,
@@ -390,6 +404,15 @@ class MatchUpController
             ]);
             return $this->quickMatchService->onCheckback($alert);
         }
+
+        // Step 2: Get ALL players (including observers) for spawn configuration
+        // If observers are ready and polling, they should be included in the game
+        $otherQmMatchPlayers = $qmMatch->players()
+            ->where('id', '<>', $qmPlayer->id)
+            ->orderBy('color', 'ASC')
+            ->get();
+
+        Log::debug('MatchUpController ** count otherQmMatchPlayers (including observers): ' . $otherQmMatchPlayers->count());
 
         if ($gameType == Game::GAME_TYPE_2VS2_AI)
         {


### PR DESCRIPTION
 Critical bug fix preventing observers from being counted toward required player count during Quick Match ready validation.

## Problem

  The `onMatchMeUp()` method was using `$qmMatch->players()` to validate if enough players were ready to start. This relationship returns **ALL** players including observers, causing incorrect validation logic.

  ### Failure Scenarios

  **Scenario 1: 2v2 Match with 3 Players + Observer (FALSE POSITIVE)** 🚨
  - Setup: 3 actual players + 1 observer
  - Expected: Wait for 4th player
  - **Actual: Match starts with only 3 actual players (unfair 2v1)**

  **Scenario 2: 1v1 Match with AFK Observer (FALSE NEGATIVE)**
  - Setup: 2 players ready, 1 observer AFK
  - Expected: Match starts with 2 players
  - Actual: May block or cause spawn issues due to observer counting

  ### Root Cause

  **Mismatch between match creation and ready-check:**
  - ✅ Match creation handlers correctly exclude observers from player count
  - ❌ Ready-check incorrectly includes observers in player count validation

 ## Solution

  Split the validation logic into two distinct queries:

  1. **Ready-Check Query**: Count only actual players (exclude `is_observer`)
  2. **Spawn Config Query**: Get all players including observers

  This ensures:
  - ✅ Observers don't count toward required player threshold
  - ✅ Observers ARE included in spawn.ini if ready and polling
  - ✅ AFK observers don't block matches
  - ✅ Incomplete teams are properly rejected