### PR TITLE
 feat: Add Twitch live streaming indicator to active matches API

### DIFF
--- a/cncnet-api/app/Http/Controllers/ApiQuickMatchController.php
+++ b/cncnet-api/app/Http/Controllers/ApiQuickMatchController.php
@@ -284,7 +284,8 @@ class ApiQuickMatchController extends Controller
                     "playerName" => $showRealNames ? $qmPlayer->player->username : "Player" . ($index + 1),
                     "playerFaction" => $sides[$qmPlayer->actual_side] ?? '',
                     "playerColor" => $qmPlayer->color,
-                    "twitchProfile" => $qmPlayer->player?->user?->twitch_profile
+                    "twitchProfile" => $qmPlayer->player?->user?->twitch_profile,
+                    "twitchLiveAtStart" => $qmPlayer->twitch_live_at_start ?? false
                 ];
             })
             ->all();
@@ -308,7 +309,8 @@ class ApiQuickMatchController extends Controller
                     "playerName" => $useRealName ? $qmPlayer->player->username : "Player" . ($index + 1),
                     "playerFaction" => $faction,
                     "playerColor" => $qmPlayer->color,
-                    "twitchProfile" => $qmPlayer->player->user->twitch_profile
+                    "twitchProfile" => $qmPlayer->player->user->twitch_profile,
+                    "twitchLiveAtStart" => $qmPlayer->twitch_live_at_start ?? false
                 ];
             })
             ->all();

--- a/cncnet-api/app/Http/Services/QuickMatchService.php
+++ b/cncnet-api/app/Http/Services/QuickMatchService.php
@@ -108,6 +108,39 @@ class QuickMatchService
         // Is player an observer?
         $this->handleObserver($qmPlayer, $player);
 
+        // Check if player is live on Twitch when match is forming
+        // This applies to both observers and regular players
+        if ($player->user?->twitch_profile)
+        {
+            try
+            {
+                $twitchUsername = $player->user->twitch_profile;
+                $qmPlayer->twitch_live_at_start = $this->twitchService->isUserLive($twitchUsername);
+
+                Log::debug('Checked Twitch live status for player', [
+                    'player_id' => $player->id,
+                    'username' => $player->username,
+                    'twitch_username' => $twitchUsername,
+                    'is_live' => $qmPlayer->twitch_live_at_start
+                ]);
+            }
+            catch (Exception $e)
+            {
+                // Fail gracefully - don't block match creation if Twitch API fails
+                $qmPlayer->twitch_live_at_start = false;
+
+                Log::warning('Failed to check Twitch live status', [
+                    'player_id' => $player->id,
+                    'username' => $player->username,
+                    'error' => $e->getMessage()
+                ]);
+            }
+        }
+        else
+        {
+            $qmPlayer->twitch_live_at_start = false;
+        }
+
         $qmPlayer->save();
         return $qmPlayer;
     }

--- a/cncnet-api/app/Models/QmMatchPlayer.php
+++ b/cncnet-api/app/Models/QmMatchPlayer.php
@@ -17,7 +17,14 @@ class QmMatchPlayer extends Model
         'color',
         'actual_side',
         'location',
-        'client_version'
+        'client_version',
+        'twitch_live_at_start'
+    ];
+
+    protected $casts = [
+        'twitch_live_at_start' => 'boolean',
+        'is_observer' => 'boolean',
+        'waiting' => 'boolean'
     ];
 
     protected $_map_side_array = null;

--- a/cncnet-api/database/migrations/2026_04_26_151010_add_twitch_live_at_start_to_qm_match_players.php
+++ b/cncnet-api/database/migrations/2026_04_26_151010_add_twitch_live_at_start_to_qm_match_players.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('qm_match_players', function (Blueprint $table) {
+            $table->boolean('twitch_live_at_start')
+                ->default(false)
+                ->after('is_observer')
+                ->comment('Player was live on Twitch when match formed');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('qm_match_players', function (Blueprint $table) {
+            $table->dropColumn('twitch_live_at_start');
+        });
+    }
+};


### PR DESCRIPTION
 ## Summary
  Adds a `twitchLiveAtStart` boolean field to the `getActiveMatches` API endpoint, allowing clients to display which players in active Quick Match games are streaming on Twitch.