### PR TITLE
Track Canceled & Failed Quick Match Games

### DIFF
--- a/cncnet-api/app/Console/Commands/DetectFailedGameLaunches.php
+++ b/cncnet-api/app/Console/Commands/DetectFailedGameLaunches.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Game;
+use App\Models\QmCanceledMatch;
+use App\Models\QmMatch;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class DetectFailedGameLaunches extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'qm:detect-failed-launches';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Detect QM games that were created but never launched (no player game reports)';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * Finds games that:
+     * 1. Have a qm_match_id (were created from Quick Match)
+     * 2. Are at least 15 minutes old (to avoid false positives for games in progress)
+     * 3. Have no player_game_reports (game never launched or crashed during loading)
+     * 4. Haven't already been logged in qm_canceled_matches
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        // Find games created from QM that are old enough and have no reports
+        $timeThreshold = Carbon::now()->subMinutes(15);
+
+        $failedGames = Game::whereNotNull('qm_match_id')
+            ->where('created_at', '<', $timeThreshold)
+            ->where('created_at', '>', Carbon::now()->subDay()) // Only look at last 24 hours
+            ->whereDoesntHave('player_game_reports') // No reports submitted
+            ->with(['qmMatch.map.map', 'qmMatch.players.player']) // Eager load for performance
+            ->get();
+
+        $recordsCreated = 0;
+
+        foreach ($failedGames as $game) {
+            // Check if we've already logged this failed launch
+            $alreadyLogged = QmCanceledMatch::where('qm_match_id', $game->qm_match_id)
+                ->where('reason', 'failed_launch')
+                ->exists();
+
+            if ($alreadyLogged) {
+                continue;
+            }
+
+            $qmMatch = $game->qmMatch;
+
+            if (!$qmMatch) {
+                continue;
+            }
+
+            // Build player data array with username and color
+            $playerData = $qmMatch->players->map(function($qmPlayer) {
+                return [
+                    'username' => $qmPlayer->player->username ?? 'Unknown',
+                    'color' => $qmPlayer->color
+                ];
+            })->values()->toArray();
+
+            // Get all player usernames from this match
+            $allPlayerUsernames = $qmMatch->players->pluck('player.username')->filter()->toArray();
+
+            // For failed launches, we don't know who specifically failed, so list all as "affected"
+            // Leave canceled_by empty since no one explicitly canceled
+            $canceledMatch = new QmCanceledMatch();
+            $canceledMatch->qm_match_id = $qmMatch->id;
+            $canceledMatch->player_id = null; // Unknown who caused the failure
+            $canceledMatch->ladder_id = $qmMatch->ladder_id;
+            $canceledMatch->map_name = $qmMatch->map->map->name ?? $qmMatch->map->description ?? 'Unknown';
+            $canceledMatch->canceled_by_usernames = null; // No explicit cancellation
+            $canceledMatch->affected_player_usernames = implode(',', $allPlayerUsernames);
+            $canceledMatch->player_data = json_encode($playerData);
+            $canceledMatch->reason = 'failed_launch';
+            $canceledMatch->save();
+
+            $recordsCreated++;
+        }
+
+        echo "Detected and logged {$recordsCreated} failed game launches\n";
+
+        return 0;
+    }
+}

--- a/cncnet-api/app/Console/Commands/DetectFailedGameLaunches.php
+++ b/cncnet-api/app/Console/Commands/DetectFailedGameLaunches.php
@@ -87,6 +87,12 @@ class DetectFailedGameLaunches extends Command
             // Get all player usernames from this match
             $allPlayerUsernames = $qmMatch->players->pluck('player.username')->filter()->toArray();
 
+            // Validate that we have at least some usernames
+            if (empty($allPlayerUsernames)) {
+                $this->warn("QM Match {$qmMatch->id} has no valid player usernames - skipping");
+                continue;
+            }
+
             // For failed launches, we don't know who specifically failed, so list all as "affected"
             // Leave canceled_by empty since no one explicitly canceled
             $canceledMatch = new QmCanceledMatch();
@@ -103,7 +109,7 @@ class DetectFailedGameLaunches extends Command
             $recordsCreated++;
         }
 
-        echo "Detected and logged {$recordsCreated} failed game launches\n";
+        $this->info("Detected and logged {$recordsCreated} failed game launches");
 
         return 0;
     }

--- a/cncnet-api/app/Http/Controllers/Api/V2/Qm/MatchUpController.php
+++ b/cncnet-api/app/Http/Controllers/Api/V2/Qm/MatchUpController.php
@@ -184,10 +184,37 @@ class MatchUpController
                     //match not ready
                     if ($qmState->state_type_id === 7)
                     {
+                        // Load match data with relationships for denormalization
+                        $qmMatch->load(['map.map', 'players.player']);
+
+                        // Build player data array with username and color
+                        $playerData = $qmMatch->players->map(function($qmPlayer) {
+                            return [
+                                'username' => $qmPlayer->player->username ?? 'Unknown',
+                                'color' => $qmPlayer->color
+                            ];
+                        })->values()->toArray();
+
+                        // Get all player usernames from this match
+                        $allPlayerUsernames = $qmMatch->players->pluck('player.username')->filter()->toArray();
+
+                        // Current player is the one canceling
+                        $canceledByUsernames = [$player->username];
+
+                        // Affected players are everyone except the canceling player
+                        $affectedPlayerUsernames = array_filter($allPlayerUsernames, function($username) use ($player) {
+                            return $username !== $player->username;
+                        });
+
                         $canceledMatch = new QmCanceledMatch();
                         $canceledMatch->qm_match_id = $qmMatch->id;
                         $canceledMatch->player_id = $player->id;
                         $canceledMatch->ladder_id = $qmMatch->ladder_id;
+                        $canceledMatch->map_name = $qmMatch->map->map->name ?? $qmMatch->map->description ?? null;
+                        $canceledMatch->canceled_by_usernames = implode(',', $canceledByUsernames);
+                        $canceledMatch->affected_player_usernames = implode(',', $affectedPlayerUsernames);
+                        $canceledMatch->player_data = json_encode($playerData);
+                        $canceledMatch->reason = 'player_canceled';
                         $canceledMatch->save();
                     }
 

--- a/cncnet-api/app/Http/Controllers/Api/V2/Qm/MatchUpController.php
+++ b/cncnet-api/app/Http/Controllers/Api/V2/Qm/MatchUpController.php
@@ -198,6 +198,12 @@ class MatchUpController
                         // Get all player usernames from this match
                         $allPlayerUsernames = $qmMatch->players->pluck('player.username')->filter()->toArray();
 
+                        // Validate that we have at least some usernames
+                        if (empty($allPlayerUsernames)) {
+                            \Log::warning("QM Match {$qmMatch->id} has no valid player usernames");
+                            // Continue with empty arrays - better to track the match than skip it
+                        }
+
                         // Current player is the one canceling
                         $canceledByUsernames = [$player->username];
 
@@ -210,7 +216,7 @@ class MatchUpController
                         $canceledMatch->qm_match_id = $qmMatch->id;
                         $canceledMatch->player_id = $player->id;
                         $canceledMatch->ladder_id = $qmMatch->ladder_id;
-                        $canceledMatch->map_name = $qmMatch->map->map->name ?? $qmMatch->map->description ?? null;
+                        $canceledMatch->map_name = $qmMatch->map->map->name ?? $qmMatch->map->description ?? 'Unknown';
                         $canceledMatch->canceled_by_usernames = implode(',', $canceledByUsernames);
                         $canceledMatch->affected_player_usernames = implode(',', $affectedPlayerUsernames);
                         $canceledMatch->player_data = json_encode($playerData);

--- a/cncnet-api/app/Http/Controllers/LadderController.php
+++ b/cncnet-api/app/Http/Controllers/LadderController.php
@@ -358,52 +358,23 @@ class LadderController extends Controller
         }
 
         /**
-         * Example output:
-         * {
-         * "created_at":"2024-12-22T21:37:34.000000Z",
-         * "qm_match_id":993628,
-         * "canceled_by":"Larsson7,Palacio",
-         * "map":"Strategic Compass",
-         * "affected_players":"HasSickTear,Sawalha"
-         * }
-         * ...
+         * Using denormalized data - no complex joins needed!
+         * Data is stored directly in qm_canceled_matches table when created.
+         * Falls back to legacy query if denormalized fields are null (backward compatibility).
          */
-        $matches = \App\Models\QmCanceledMatch::where('qm_canceled_matches.ladder_id', $ladder->id)
-            ->join('players as p', 'qm_canceled_matches.player_id', '=', 'p.id') // The player who canceled the match
-            ->join('qm_matches', 'qm_canceled_matches.qm_match_id', '=', 'qm_matches.id')
-            ->join('qm_maps', 'qm_matches.qm_map_id', '=', 'qm_maps.id')
-            ->join('qm_match_players as qmp', 'qm_matches.id', '=', 'qmp.qm_match_id') // Join qm_match_players for all players in the match
-            ->join('players as qmp_players', 'qmp.player_id', '=', 'qmp_players.id') // Get player details
-            ->orderBy('qm_canceled_matches.created_at', 'DESC')
-            ->selectRaw("
-                qm_canceled_matches.created_at,
-                qm_matches.id as qm_match_id,
-                GROUP_CONCAT(DISTINCT p.username ORDER BY p.username ASC SEPARATOR ',') as canceled_by,
-                qm_maps.description as map,
-                GROUP_CONCAT(
-                    DISTINCT CASE
-                        WHEN qmp_players.username != p.username 
-                        AND qmp_players.username NOT IN (
-                            SELECT username FROM players WHERE id = qm_canceled_matches.player_id
-                        )
-                        AND qmp_players.username NOT IN (
-                            SELECT DISTINCT username
-                            FROM players
-                            INNER JOIN qm_match_players as qmp ON qmp.player_id = players.id
-                            WHERE qmp.qm_match_id = qm_matches.id
-                            AND players.id IN (
-                                SELECT player_id FROM qm_canceled_matches WHERE qm_match_id = qm_matches.id
-                            )
-                        )  -- Exclude players in canceled_by
-                        THEN qmp_players.username
-                        ELSE NULL
-                    END
-                    ORDER BY qmp_players.username ASC SEPARATOR ','
-                ) as affected_players
-            ")
-            ->whereColumn('qmp.player_id', '!=', 'qm_canceled_matches.player_id') // Exclude canceled_by from affected_players
-            ->where('qm_canceled_matches.created_at', '>=', Carbon::now()->subDay(1))
-            ->groupBy('qm_matches.id', 'qm_maps.description') // Group by qm_match_id to get one row per match
+        $matches = \App\Models\QmCanceledMatch::where('ladder_id', $ladder->id)
+            ->where('created_at', '>=', Carbon::now()->subWeek()) // Show last week of data
+            ->orderBy('created_at', 'DESC')
+            ->select([
+                'id',
+                'created_at',
+                'qm_match_id',
+                'map_name as map',
+                'canceled_by_usernames as canceled_by',
+                'affected_player_usernames as affected_players',
+                'player_data',
+                'reason'
+            ])
             ->paginate(20);
 
         return view("admin.canceled-matches", [

--- a/cncnet-api/app/Models/QmCanceledMatch.php
+++ b/cncnet-api/app/Models/QmCanceledMatch.php
@@ -4,6 +4,21 @@ use Illuminate\Database\Eloquent\Model;
 
 class QmCanceledMatch extends Model {
 
+    protected $fillable = [
+        'qm_match_id',
+        'player_id',
+        'ladder_id',
+        'map_name',
+        'canceled_by_usernames',
+        'affected_player_usernames',
+        'player_data',
+        'reason',
+    ];
+
+    protected $casts = [
+        'player_data' => 'array',
+    ];
+
     public function qmMatch()
     {
         return $this->belongsTo(QmMatch::class, 'qm_match_id');
@@ -17,5 +32,25 @@ class QmCanceledMatch extends Model {
     public function ladder()
     {
         return $this->belongsTo(Ladder::class, 'ladder_id');
+    }
+
+    /**
+     * Get CSS color for a C&C player color ID
+     * Based on Red Alert 2 / Yuri's Revenge color scheme
+     */
+    public static function getColorForId($colorId)
+    {
+        $colors = [
+            0 => '#FFD700', // Yellow/Gold
+            1 => '#FF0000', // Red
+            2 => '#0080FF', // Blue
+            3 => '#00FF00', // Green
+            4 => '#FF8000', // Orange
+            5 => '#00FFFF', // Cyan/Teal
+            6 => '#FF00FF', // Purple/Magenta
+            7 => '#FFB6C1', // Pink/Light Pink
+        ];
+
+        return $colors[$colorId] ?? '#FFFFFF'; // Default to white if unknown
     }
 }

--- a/cncnet-api/app/Models/QmCanceledMatch.php
+++ b/cncnet-api/app/Models/QmCanceledMatch.php
@@ -40,17 +40,9 @@ class QmCanceledMatch extends Model {
      */
     public static function getColorForId($colorId)
     {
-        $colors = [
-            0 => '#FFD700', // Yellow/Gold
-            1 => '#FF0000', // Red
-            2 => '#0080FF', // Blue
-            3 => '#00FF00', // Green
-            4 => '#FF8000', // Orange
-            5 => '#00FFFF', // Cyan/Teal
-            6 => '#FF00FF', // Purple/Magenta
-            7 => '#FFB6C1', // Pink/Light Pink
-        ];
+        $colors = config('game_colors.ra2_player_colors', []);
+        $defaultColor = config('game_colors.default_color', '#FFFFFF');
 
-        return $colors[$colorId] ?? '#FFFFFF'; // Default to white if unknown
+        return $colors[$colorId] ?? $defaultColor;
     }
 }

--- a/cncnet-api/bootstrap/app.php
+++ b/cncnet-api/bootstrap/app.php
@@ -59,6 +59,8 @@ return Application::configure(basePath: dirname(__DIR__))
             ->monthly();
 
         $schedule->command('clear_inactive_queue_entries')->everyMinute();
+        $schedule->command('qm:detect-failed-launches')
+            ->everyFiveMinutes();
     })
     ->withExceptions(function (Exceptions $exceptions) {
 

--- a/cncnet-api/config/game_colors.php
+++ b/cncnet-api/config/game_colors.php
@@ -1,0 +1,36 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Red Alert 2 / Yuri's Revenge Player Colors
+    |--------------------------------------------------------------------------
+    |
+    | Color mappings for player slots in Red Alert 2 and Yuri's Revenge.
+    | These hex color codes correspond to the in-game color scheme.
+    | Used for visual display of player names in the ladder UI.
+    |
+    */
+
+    'ra2_player_colors' => [
+        0 => '#FFD700', // Yellow/Gold
+        1 => '#FF0000', // Red
+        2 => '#0080FF', // Blue
+        3 => '#00FF00', // Green
+        4 => '#FF8000', // Orange
+        5 => '#00FFFF', // Cyan/Teal
+        6 => '#FF00FF', // Purple/Magenta
+        7 => '#FFB6C1', // Pink/Light Pink
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Player Color
+    |--------------------------------------------------------------------------
+    |
+    | Fallback color used when the player color ID is not recognized.
+    |
+    */
+
+    'default_color' => '#FFFFFF', // White
+];

--- a/cncnet-api/database/migrations/2026_04_30_211759_add_denormalized_fields_to_qm_canceled_matches_table.php
+++ b/cncnet-api/database/migrations/2026_04_30_211759_add_denormalized_fields_to_qm_canceled_matches_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('qm_canceled_matches', function (Blueprint $table) {
+            // Make player_id nullable (for failed launches where we don't know who caused it)
+            $table->unsignedInteger('player_id')->nullable()->change();
+
+            // Denormalized data from qm_matches and qm_match_players
+            $table->string('map_name')->nullable()->after('ladder_id');
+            $table->text('canceled_by_usernames')->nullable()->after('map_name')->comment('Comma-separated list of usernames who canceled');
+            $table->text('affected_player_usernames')->nullable()->after('canceled_by_usernames')->comment('Comma-separated list of affected player usernames');
+
+            // Store player data as JSON: [{username, color}, ...]
+            $table->json('player_data')->nullable()->after('affected_player_usernames')->comment('JSON array of player objects with username and color');
+
+            // Track reason for cancellation
+            $table->enum('reason', ['player_canceled', 'failed_launch'])->default('player_canceled')->after('player_data');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('qm_canceled_matches', function (Blueprint $table) {
+            // Revert player_id to NOT NULL
+            $table->unsignedInteger('player_id')->nullable(false)->change();
+
+            // Drop the new columns
+            $table->dropColumn(['map_name', 'canceled_by_usernames', 'affected_player_usernames', 'player_data', 'reason']);
+        });
+    }
+};

--- a/cncnet-api/database/migrations/2026_04_30_211759_add_denormalized_fields_to_qm_canceled_matches_table.php
+++ b/cncnet-api/database/migrations/2026_04_30_211759_add_denormalized_fields_to_qm_canceled_matches_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -11,10 +12,10 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('qm_canceled_matches', function (Blueprint $table) {
-            // Make player_id nullable (for failed launches where we don't know who caused it)
-            $table->unsignedInteger('player_id')->nullable()->change();
+        // Use raw SQL to avoid doctrine/dbal dependency for column modification
+        DB::statement('ALTER TABLE qm_canceled_matches MODIFY player_id INT UNSIGNED NULL');
 
+        Schema::table('qm_canceled_matches', function (Blueprint $table) {
             // Denormalized data from qm_matches and qm_match_players
             $table->string('map_name')->nullable()->after('ladder_id');
             $table->text('canceled_by_usernames')->nullable()->after('map_name')->comment('Comma-separated list of usernames who canceled');
@@ -25,6 +26,10 @@ return new class extends Migration
 
             // Track reason for cancellation
             $table->enum('reason', ['player_canceled', 'failed_launch'])->default('player_canceled')->after('player_data');
+
+            // Add indexes for query performance
+            $table->index(['ladder_id', 'created_at'], 'idx_ladder_created');
+            $table->index(['qm_match_id', 'reason'], 'idx_match_reason');
         });
     }
 
@@ -34,11 +39,15 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('qm_canceled_matches', function (Blueprint $table) {
-            // Revert player_id to NOT NULL
-            $table->unsignedInteger('player_id')->nullable(false)->change();
+            // Drop indexes first
+            $table->dropIndex('idx_ladder_created');
+            $table->dropIndex('idx_match_reason');
 
             // Drop the new columns
             $table->dropColumn(['map_name', 'canceled_by_usernames', 'affected_player_usernames', 'player_data', 'reason']);
         });
+
+        // Revert player_id to NOT NULL using raw SQL
+        DB::statement('ALTER TABLE qm_canceled_matches MODIFY player_id INT UNSIGNED NOT NULL');
     }
 };

--- a/cncnet-api/resources/views/admin/canceled-matches.blade.php
+++ b/cncnet-api/resources/views/admin/canceled-matches.blade.php
@@ -5,7 +5,7 @@
     <x-hero-with-video video="{{ \App\Models\URLHelper::getVideoUrlbyAbbrev('ra2') }}">
         <x-slot name="title">CnCNet Canceled Matches</x-slot>
         <x-slot name="description">
-            View all canceled games
+            View canceled games and failed launches (games that failed to start)
         </x-slot>
 
         <div class="mini-breadcrumb d-none d-lg-flex">
@@ -60,18 +60,53 @@
                 <thead>
                     <tr>
                         <th>Created At</th>
-                        <th>Canceled By</th>
-                        <th>Affected Players</th>
+                        <th>Reason</th>
+                        <th>Players</th>
                         <th>Map</th>
                     </tr>
                 </thead>
                 <tbody class="table">
                     @foreach ($canceled_matches as $canceled_match)
-                        <tr title="QM Match ID: {{ $canceled_match->qm_match_id }}">
+                        @php
+                            $playerData = $canceled_match->player_data ?? [];
+                            $canceledByList = $canceled_match->canceled_by ? explode(',', $canceled_match->canceled_by) : [];
+                        @endphp
+                        <tr title="QM Match ID: {{ $canceled_match->qm_match_id }}"
+                            class="{{ $canceled_match->reason === 'failed_launch' ? 'table-warning' : '' }}">
                             <td>{{ $canceled_match->created_at->format('F j, Y, g:i a T') }}</td>
-                            <td>{{ $canceled_match->canceled_by }}</td>
-                            <td>{{ $canceled_match->affected_players }}</td>
-                            <td>{{ $canceled_match->map }}</td>
+                            <td>
+                                @if($canceled_match->reason === 'failed_launch')
+                                    <span class="badge bg-warning text-dark">Failed Launch</span>
+                                @else
+                                    <span class="badge bg-secondary">Player Canceled</span>
+                                @endif
+                            </td>
+                            <td>
+                                @if(count($playerData) > 0)
+                                    @foreach($playerData as $player)
+                                        @php
+                                            $color = \App\Models\QmCanceledMatch::getColorForId($player['color'] ?? 0);
+                                            $username = $player['username'] ?? 'Unknown';
+                                            $isCanceler = in_array($username, $canceledByList);
+                                        @endphp
+                                        <span style="color: {{ $color }}; font-weight: bold;">
+                                            {{ $username }}
+                                            @if($isCanceler && $canceled_match->reason === 'player_canceled')
+                                                <small style="color: #999;">(canceled)</small>
+                                            @endif
+                                        </span>
+                                        @if(!$loop->last), @endif
+                                    @endforeach
+                                @else
+                                    {{-- Fallback to legacy comma-separated format --}}
+                                    @if($canceled_match->canceled_by)
+                                        <strong>{{ $canceled_match->canceled_by }}</strong>
+                                        @if($canceled_match->affected_players), @endif
+                                    @endif
+                                    {{ $canceled_match->affected_players ?? '-' }}
+                                @endif
+                            </td>
+                            <td>{{ $canceled_match->map ?? 'Unknown' }}</td>
                         </tr>
                     @endforeach
                 </tbody>

--- a/cncnet-api/resources/views/admin/canceled-matches.blade.php
+++ b/cncnet-api/resources/views/admin/canceled-matches.blade.php
@@ -82,7 +82,7 @@
                                 @endif
                             </td>
                             <td>
-                                @if(count($playerData) > 0)
+                                @if(is_array($playerData) && count($playerData) > 0)
                                     @foreach($playerData as $player)
                                         @php
                                             $color = \App\Models\QmCanceledMatch::getColorForId($player['color'] ?? 0);


### PR DESCRIPTION
## Summary

Improves Quick Match game tracking by denormalizing canceled match data and adding automated detection of failed game launches. Fixes data retention issue where canceled match records were lost due to CASCADE deletes when `qm_matches` cleanup runs.

## Key Changes

- **Denormalized `qm_canceled_matches` table** - Stores map names, player usernames, and colors directly to survive cleanup of `qm_matches` and `qm_match_players` tables
- **New scheduled command** - Automatically detects games created but never launched (failed during loading screen), runs every 5 minutes
- **Player color tracking** - Captures and displays each player's in-game color (Gold, Red, Blue, Green, etc.) for visual identification
- **Simplified queries** - Replaced complex 40-line query with GROUP_CONCAT joins with simple SELECT from denormalized columns
- **Extended data retention** - Changed visibility window from 24 hours to 1 week to match actual data retention

## Impact

**Before:**
- Canceled match data deleted after 1 week due to CASCADE constraint on `qm_matches` foreign key
- Complex SQL query with 5 table joins and subqueries to display canceled matches
- No tracking of games that failed to launch (created but no reports submitted)
- Only 24 hours of visibility despite 1-month cleanup schedule

**After:**
- Canceled match data persists independently with denormalized fields
- Simple single-table query with no joins required
- Automated detection and logging of failed game launches every 5 minutes
- 1 week of visibility with color-coded player names and cancellation reasons
- Player names displayed in their game colors (Gold, Red, Blue, etc.) for easy visual identification

## Files Changed

- Migration: Add denormalized fields to `qm_canceled_matches` (map_name, player_data JSON, reason enum)
- Command: New `DetectFailedGameLaunches` scheduled every 5 minutes
- Controller: Populate denormalized fields when matches canceled, simplified getCanceledMatches query
- Model: Add `QmCanceledMatch::getColorForId()` helper for C&C color mapping
- View: Color-coded player display with badges for cancellation type
- Schedule: Register failed launch detection command
