### PR TITLE
Admin game point reprocessing and stats fixes

### DIFF
--- a/cncnet-api/app/Http/Controllers/AdminController.php
+++ b/cncnet-api/app/Http/Controllers/AdminController.php
@@ -1017,6 +1017,41 @@ class AdminController extends Controller
         return redirect()->back();
     }
 
+    public function reprocessGamePoints(Request $request)
+    {
+        $winningTeam = $request->input('winning_team', null);
+
+        \Log::info("AdminController.reprocessGamePoints called", [
+            'game_id' => $request->game_id,
+            'winning_team_input' => $winningTeam,
+            'all_inputs' => $request->all()
+        ]);
+
+        $status = $this->adminService->reprocessGamePoints($request->game_id, $request->user()->name, $winningTeam);
+
+        // Build success message
+        if ($winningTeam && str_starts_with($winningTeam, 'player_'))
+        {
+            $playerId = (int) str_replace('player_', '', $winningTeam);
+            $player = \App\Models\Player::find($playerId);
+            $playerName = $player ? $player->username : "Player #$playerId";
+            $message = "Game points reprocessed with $playerName set as winner (status: $status)";
+        }
+        else if ($winningTeam)
+        {
+            $message = "Game points reprocessed with Team $winningTeam set as winner (status: $status)";
+        }
+        else
+        {
+            $message = "Game points reprocessed (status: $status)";
+        }
+
+        \Log::info("Reprocess complete", ['message' => $message, 'status' => $status]);
+
+        $request->session()->flash('success', $message);
+        return redirect()->back();
+    }
+
     public function remSide(Request $request, $ladderId = null)
     {
         $ladder = Ladder::find($ladderId);

--- a/cncnet-api/app/Http/Controllers/AdminController.php
+++ b/cncnet-api/app/Http/Controllers/AdminController.php
@@ -1027,7 +1027,12 @@ class AdminController extends Controller
             'all_inputs' => $request->all()
         ]);
 
-        $status = $this->adminService->reprocessGamePoints($request->game_id, $request->user()->name, $winningTeam);
+        $status = $this->adminService->reprocessGamePoints(
+            $request->game_id,
+            $request->user()->name,
+            $winningTeam,
+            $request->user()
+        );
 
         // Build success message
         if ($winningTeam && str_starts_with($winningTeam, 'player_'))

--- a/cncnet-api/app/Http/Controllers/AdminController.php
+++ b/cncnet-api/app/Http/Controllers/AdminController.php
@@ -1024,8 +1024,42 @@ class AdminController extends Controller
         \Log::info("AdminController.reprocessGamePoints called", [
             'game_id' => $request->game_id,
             'winning_team_input' => $winningTeam,
-            'all_inputs' => $request->all()
+            'ladder_id' => $request->route('ladderId')
         ]);
+
+        // Validate game exists
+        $game = \App\Models\Game::find($request->game_id);
+        if (!$game) {
+            return redirect()->back()->withErrors(['game_id' => 'Game not found']);
+        }
+
+        // Validate winning_team if provided
+        if ($winningTeam !== null && $winningTeam !== '') {
+            $gameReport = $game->report()->first();
+            if (!$gameReport) {
+                return redirect()->back()->withErrors(['game' => 'Game report not found']);
+            }
+
+            // Get non-spectator players
+            $playerGameReports = $gameReport->playerGameReports()->where('spectator', 0)->get();
+
+            if (str_starts_with($winningTeam, 'player_')) {
+                // Validate player exists in this game
+                $playerId = (int) str_replace('player_', '', $winningTeam);
+                $playerExists = $playerGameReports->contains('player_id', $playerId);
+
+                if (!$playerExists) {
+                    return redirect()->back()->withErrors(['winning_team' => 'Selected player not found in this game']);
+                }
+            } else {
+                // Validate team exists in this game
+                $teamExists = $playerGameReports->contains('team', $winningTeam);
+
+                if (!$teamExists) {
+                    return redirect()->back()->withErrors(['winning_team' => 'Selected team not found in this game']);
+                }
+            }
+        }
 
         $status = $this->adminService->reprocessGamePoints(
             $request->game_id,

--- a/cncnet-api/app/Http/Controllers/ApiLadderController.php
+++ b/cncnet-api/app/Http/Controllers/ApiLadderController.php
@@ -437,16 +437,19 @@ class ApiLadderController extends Controller
             return 604;
         }
 
-        if ($gameReport->fps < $history->ladder->qmLadderRules->bail_fps)
-        {
-            // FPS too low, no points awarded
-            return 630;
-        }
-
         if ($gameReport->duration < $history->ladder->qmLadderRules->bail_time)
         {
             // Duration too low, no points awarded
             return 660;
+        }
+
+        // Only apply FPS filter on short games (< 2 minutes)
+        // Prevents awarding points for instant disconnects/crashes at game start
+        // Long games with low FPS are still legitimate matches (poor performance, not bail)
+        if ($gameReport->duration < 120 && $gameReport->fps < $history->ladder->qmLadderRules->bail_fps)
+        {
+            // FPS too low on short game, likely disconnect/crash
+            return 630;
         }
 
         foreach ($clanGameReports as $clanGameReport)
@@ -635,16 +638,19 @@ class ApiLadderController extends Controller
             return 604;
         }
 
-        if ($gameReport->fps < $history->ladder->qmLadderRules->bail_fps)
-        {
-            // FPS too low, no points awarded
-            return 630;
-        }
-
         if ($gameReport->duration < $history->ladder->qmLadderRules->bail_time)
         {
             // Duration too low, no points awarded
             return 660;
+        }
+
+        // Only apply FPS filter on short games (< 2 minutes)
+        // Prevents awarding points for instant disconnects/crashes at game start
+        // Long games with low FPS are still legitimate matches (poor performance, not bail)
+        if ($gameReport->duration < 120 && $gameReport->fps < $history->ladder->qmLadderRules->bail_fps)
+        {
+            // FPS too low on short game, likely disconnect/crash
+            return 630;
         }
 
         $disconnected = 0;
@@ -831,16 +837,19 @@ class ApiLadderController extends Controller
             return 604;
         }
 
-        if ($gameReport->fps < $history->ladder->qmLadderRules->bail_fps)
-        {
-            // FPS too low, no points awarded
-            return 630;
-        }
-
         if ($gameReport->duration < $history->ladder->qmLadderRules->bail_time)
         {
             // Duration too low, no points awarded
             return 660;
+        }
+
+        // Only apply FPS filter on short games (< 2 minutes)
+        // Prevents awarding points for instant disconnects/crashes at game start
+        // Long games with low FPS are still legitimate matches (poor performance, not bail)
+        if ($gameReport->duration < 120 && $gameReport->fps < $history->ladder->qmLadderRules->bail_fps)
+        {
+            // FPS too low on short game, likely disconnect/crash
+            return 630;
         }
 
         $disconnected = 0;

--- a/cncnet-api/app/Http/Services/AdminService.php
+++ b/cncnet-api/app/Http/Services/AdminService.php
@@ -105,6 +105,186 @@ class AdminService
     }
 
     /**
+     * Reprocess points for a specific game
+     * Creates a new manual game report to preserve original data and maintain audit trail
+     *
+     * @param int $gameId - The game ID to reprocess
+     * @param string $userName - Admin username performing the action
+     * @param string|null $winningTeam - Optional team override (e.g., "A", "B"). If provided, manually sets won flags for that team.
+     */
+    public function reprocessGamePoints($gameId, $userName, $winningTeam = null)
+    {
+        \Log::info("=== REPROCESS GAME POINTS START ===", [
+            'game_id' => $gameId,
+            'admin' => $userName,
+            'winning_team_override' => $winningTeam
+        ]);
+
+        $game = \App\Models\Game::find($gameId);
+        if ($game === null) return "Game not found";
+
+        $currentGameReport = $game->report()->first();
+        if ($currentGameReport === null) return "Game Report not found";
+
+        $history = $game->ladderHistory;
+        if ($history === null) return "Ladder History not found";
+
+        // Undo existing points from cache using current report
+        $this->ladderService->undoCache($currentGameReport);
+
+        // Mark current report as no longer the best
+        $currentGameReport->best_report = false;
+        $currentGameReport->save();
+
+        // Create new manual game report (preserves original data)
+        $newGameReport = new \App\Models\GameReport();
+        $newGameReport->game_id = $currentGameReport->game_id;
+        $newGameReport->player_id = $currentGameReport->player_id;
+        $newGameReport->best_report = true;
+        $newGameReport->manual_report = true; // Mark as admin-generated
+        $newGameReport->duration = $currentGameReport->duration;
+        $newGameReport->valid = $currentGameReport->valid;
+        $newGameReport->finished = $currentGameReport->finished;
+        $newGameReport->fps = $currentGameReport->fps;
+        $newGameReport->oos = $currentGameReport->oos;
+        $newGameReport->pings_sent = $currentGameReport->pings_sent;
+        $newGameReport->pings_received = $currentGameReport->pings_received;
+        $newGameReport->clan_id = $currentGameReport->clan_id;
+        $newGameReport->save();
+
+        // Detect if this is a 1v1 player override (format: "player_123") or team override (format: "A", "B", etc)
+        $is1v1PlayerOverride = false;
+        $winningPlayerId = null;
+        if ($winningTeam !== null && $winningTeam !== '' && str_starts_with($winningTeam, 'player_'))
+        {
+            $is1v1PlayerOverride = true;
+            $winningPlayerId = (int) str_replace('player_', '', $winningTeam);
+        }
+
+        // Clone all player game reports from current report
+        $currentPlayerGameReports = $currentGameReport->playerGameReports()->get();
+        foreach ($currentPlayerGameReports as $oldPgr)
+        {
+            $newPgr = new \App\Models\PlayerGameReport();
+            $newPgr->game_report_id = $newGameReport->id;
+            $newPgr->game_id = $oldPgr->game_id;
+            $newPgr->player_id = $oldPgr->player_id;
+            $newPgr->local_id = $oldPgr->local_id;
+            $newPgr->local_team_id = $oldPgr->local_team_id;
+            $newPgr->points = 0; // Will be recalculated
+            $newPgr->stats_id = $oldPgr->stats_id;
+            $newPgr->team = $oldPgr->team;
+            $newPgr->spawn = $oldPgr->spawn;
+            $newPgr->clan_id = $oldPgr->clan_id;
+            $newPgr->spectator = $oldPgr->spectator;
+
+            // If admin selected winner, apply override
+            if (($winningTeam !== null && $winningTeam !== '' || $is1v1PlayerOverride) && !$oldPgr->spectator)
+            {
+                $isWinner = false;
+
+                // For 1v1: match by player_id
+                if ($is1v1PlayerOverride)
+                {
+                    $isWinner = ($oldPgr->player_id == $winningPlayerId);
+                }
+                // For 2v2/clan: match by team
+                else
+                {
+                    $isWinner = ($oldPgr->team === $winningTeam);
+                }
+
+                if ($isWinner)
+                {
+                    $newPgr->won = true;
+                    $newPgr->defeated = false;
+                    $newPgr->draw = false;
+                    $newPgr->disconnected = false;
+                    $newPgr->no_completion = false;
+                    $newPgr->quit = false;
+                }
+                else
+                {
+                    $newPgr->won = false;
+                    $newPgr->defeated = true;
+                    $newPgr->draw = false;
+                    $newPgr->disconnected = false;
+                    $newPgr->no_completion = false;
+                    $newPgr->quit = false;
+                }
+            }
+            else
+            {
+                // Keep original outcome
+                $newPgr->won = $oldPgr->won;
+                $newPgr->defeated = $oldPgr->defeated;
+                $newPgr->draw = $oldPgr->draw;
+                $newPgr->disconnected = $oldPgr->disconnected;
+                $newPgr->no_completion = $oldPgr->no_completion;
+                $newPgr->quit = $oldPgr->quit;
+            }
+
+            $newPgr->save();
+        }
+
+        // Update game to point to new report
+        $game->game_report_id = $newGameReport->id;
+        $game->save();
+
+        // Determine ladder type and call appropriate award method
+        $apiLadderController = new \App\Http\Controllers\ApiLadderController();
+
+        if ($history->ladder->ladder_type == \App\Models\Ladder::CLAN_MATCH)
+        {
+            $status = $apiLadderController->awardClanPoints($newGameReport, $history);
+        }
+        else if ($history->ladder->ladder_type == \App\Models\Ladder::TWO_VS_TWO)
+        {
+            $status = $apiLadderController->awardTeamPoints($newGameReport, $history);
+        }
+        else // 1vs1
+        {
+            $status = $apiLadderController->awardPlayerPoints($newGameReport, $history);
+        }
+
+        // Update cache with new points
+        $this->ladderService->updateCache($newGameReport);
+
+        // Log the reprocess action
+        $logMessage = 'Game points reprocessed';
+        if ($is1v1PlayerOverride)
+        {
+            $winningPlayer = \App\Models\Player::find($winningPlayerId);
+            $logMessage .= " with winner override: " . ($winningPlayer ? $winningPlayer->username : "Player #$winningPlayerId");
+        }
+        else if ($winningTeam)
+        {
+            $logMessage .= " with team override: Team $winningTeam";
+        }
+
+        activity()
+            ->performedOn($game)
+            ->causedBy(auth()->user())
+            ->withProperties([
+                'status' => $status,
+                'admin' => $userName,
+                'winning_team_override' => $winningTeam,
+                'winning_player_id' => $winningPlayerId,
+                'old_report_id' => $currentGameReport->id,
+                'new_report_id' => $newGameReport->id
+            ])
+            ->log($logMessage);
+
+        \Log::info("=== REPROCESS GAME POINTS END ===", [
+            'status' => $status,
+            'old_report_id' => $currentGameReport->id,
+            'new_report_id' => $newGameReport->id
+        ]);
+
+        return $status;
+    }
+
+    /**
      * Identify games where only one player submitted a game_report.
      * Return the player who did not submit a gamereport, also return the game_id and map
      * TODO return who the opponent was too

--- a/cncnet-api/app/Http/Services/AdminService.php
+++ b/cncnet-api/app/Http/Services/AdminService.php
@@ -137,6 +137,21 @@ class AdminService
                 return "No player reports found";
             }
 
+            // Capture before state for audit trail
+            $beforeState = [];
+            foreach ($currentPlayerGameReports as $pgr) {
+                $beforeState[] = [
+                    'player_id' => $pgr->player_id,
+                    'player_username' => $pgr->player->username ?? 'Unknown',
+                    'team' => $pgr->team,
+                    'won' => $pgr->won,
+                    'defeated' => $pgr->defeated,
+                    'draw' => $pgr->draw,
+                    'disconnected' => $pgr->disconnected,
+                    'points' => $pgr->points,
+                ];
+            }
+
             // Undo existing points from cache using current report
             $this->ladderService->undoCache($currentGameReport);
 
@@ -257,6 +272,35 @@ class AdminService
             // Update cache with new points
             $this->ladderService->updateCache($newGameReport);
 
+            // Capture after state for audit trail
+            $newPlayerGameReports = $newGameReport->playerGameReports()->get();
+            $afterState = [];
+            foreach ($newPlayerGameReports as $pgr) {
+                $afterState[] = [
+                    'player_id' => $pgr->player_id,
+                    'player_username' => $pgr->player->username ?? 'Unknown',
+                    'team' => $pgr->team,
+                    'won' => $pgr->won,
+                    'defeated' => $pgr->defeated,
+                    'draw' => $pgr->draw,
+                    'disconnected' => $pgr->disconnected,
+                    'points' => $pgr->points,
+                ];
+            }
+
+            // Build changes summary for quick reference
+            $changes = [];
+            foreach ($beforeState as $index => $before) {
+                $after = $afterState[$index] ?? null;
+                if ($after && ($before['won'] != $after['won'] || $before['points'] != $after['points'])) {
+                    $changes[] = $before['player_username'] . ': '
+                        . ($before['won'] ? 'W' : ($before['defeated'] ? 'L' : 'D'))
+                        . ' (' . $before['points'] . 'pts) → '
+                        . ($after['won'] ? 'W' : ($after['defeated'] ? 'L' : 'D'))
+                        . ' (' . $after['points'] . 'pts)';
+                }
+            }
+
             // Log the reprocess action
             $logMessage = 'Game points reprocessed';
             if ($is1v1PlayerOverride)
@@ -281,7 +325,10 @@ class AdminService
                         'winning_team_override' => $winningTeam,
                         'winning_player_id' => $winningPlayerId,
                         'old_report_id' => $currentGameReport->id,
-                        'new_report_id' => $newGameReport->id
+                        'new_report_id' => $newGameReport->id,
+                        'before_state' => $beforeState,
+                        'after_state' => $afterState,
+                        'changes_summary' => $changes
                     ])
                     ->log($logMessage);
             } else {

--- a/cncnet-api/app/Http/Services/AdminService.php
+++ b/cncnet-api/app/Http/Services/AdminService.php
@@ -111,8 +111,9 @@ class AdminService
      * @param int $gameId - The game ID to reprocess
      * @param string $userName - Admin username performing the action
      * @param string|null $winningTeam - Optional team override (e.g., "A", "B"). If provided, manually sets won flags for that team.
+     * @param \App\Models\User|null $authUser - The authenticated user performing the action (for activity log)
      */
-    public function reprocessGamePoints($gameId, $userName, $winningTeam = null)
+    public function reprocessGamePoints($gameId, $userName, $winningTeam = null, $authUser = null)
     {
         \Log::info("=== REPROCESS GAME POINTS START ===", [
             'game_id' => $gameId,
@@ -120,168 +121,181 @@ class AdminService
             'winning_team_override' => $winningTeam
         ]);
 
-        $game = \App\Models\Game::find($gameId);
-        if ($game === null) return "Game not found";
+        return DB::transaction(function () use ($gameId, $userName, $winningTeam, $authUser) {
+            $game = \App\Models\Game::find($gameId);
+            if ($game === null) return "Game not found";
 
-        $currentGameReport = $game->report()->first();
-        if ($currentGameReport === null) return "Game Report not found";
+            $currentGameReport = $game->report()->first();
+            if ($currentGameReport === null) return "Game Report not found";
 
-        $history = $game->ladderHistory;
-        if ($history === null) return "Ladder History not found";
+            $history = $game->ladderHistory;
+            if ($history === null) return "Ladder History not found";
 
-        // Undo existing points from cache using current report
-        $this->ladderService->undoCache($currentGameReport);
-
-        // Mark current report as no longer the best
-        $currentGameReport->best_report = false;
-        $currentGameReport->save();
-
-        // Create new manual game report (preserves original data)
-        $newGameReport = new \App\Models\GameReport();
-        $newGameReport->game_id = $currentGameReport->game_id;
-        $newGameReport->player_id = $currentGameReport->player_id;
-        $newGameReport->best_report = true;
-        $newGameReport->manual_report = true; // Mark as admin-generated
-        $newGameReport->duration = $currentGameReport->duration;
-        $newGameReport->valid = $currentGameReport->valid;
-        $newGameReport->finished = $currentGameReport->finished;
-        $newGameReport->fps = $currentGameReport->fps;
-        $newGameReport->oos = $currentGameReport->oos;
-        $newGameReport->pings_sent = $currentGameReport->pings_sent;
-        $newGameReport->pings_received = $currentGameReport->pings_received;
-        $newGameReport->clan_id = $currentGameReport->clan_id;
-        $newGameReport->save();
-
-        // Detect if this is a 1v1 player override (format: "player_123") or team override (format: "A", "B", etc)
-        $is1v1PlayerOverride = false;
-        $winningPlayerId = null;
-        if ($winningTeam !== null && $winningTeam !== '' && str_starts_with($winningTeam, 'player_'))
-        {
-            $is1v1PlayerOverride = true;
-            $winningPlayerId = (int) str_replace('player_', '', $winningTeam);
-        }
-
-        // Clone all player game reports from current report
-        $currentPlayerGameReports = $currentGameReport->playerGameReports()->get();
-        foreach ($currentPlayerGameReports as $oldPgr)
-        {
-            $newPgr = new \App\Models\PlayerGameReport();
-            $newPgr->game_report_id = $newGameReport->id;
-            $newPgr->game_id = $oldPgr->game_id;
-            $newPgr->player_id = $oldPgr->player_id;
-            $newPgr->local_id = $oldPgr->local_id;
-            $newPgr->local_team_id = $oldPgr->local_team_id;
-            $newPgr->points = 0; // Will be recalculated
-            $newPgr->stats_id = $oldPgr->stats_id;
-            $newPgr->team = $oldPgr->team;
-            $newPgr->spawn = $oldPgr->spawn;
-            $newPgr->clan_id = $oldPgr->clan_id;
-            $newPgr->spectator = $oldPgr->spectator;
-
-            // If admin selected winner, apply override
-            if (($winningTeam !== null && $winningTeam !== '' || $is1v1PlayerOverride) && !$oldPgr->spectator)
-            {
-                $isWinner = false;
-
-                // For 1v1: match by player_id
-                if ($is1v1PlayerOverride)
-                {
-                    $isWinner = ($oldPgr->player_id == $winningPlayerId);
-                }
-                // For 2v2/clan: match by team
-                else
-                {
-                    $isWinner = ($oldPgr->team === $winningTeam);
-                }
-
-                if ($isWinner)
-                {
-                    $newPgr->won = true;
-                    $newPgr->defeated = false;
-                    $newPgr->draw = false;
-                    $newPgr->disconnected = false;
-                    $newPgr->no_completion = false;
-                    $newPgr->quit = false;
-                }
-                else
-                {
-                    $newPgr->won = false;
-                    $newPgr->defeated = true;
-                    $newPgr->draw = false;
-                    $newPgr->disconnected = false;
-                    $newPgr->no_completion = false;
-                    $newPgr->quit = false;
-                }
-            }
-            else
-            {
-                // Keep original outcome
-                $newPgr->won = $oldPgr->won;
-                $newPgr->defeated = $oldPgr->defeated;
-                $newPgr->draw = $oldPgr->draw;
-                $newPgr->disconnected = $oldPgr->disconnected;
-                $newPgr->no_completion = $oldPgr->no_completion;
-                $newPgr->quit = $oldPgr->quit;
+            // Clone all player game reports from current report
+            $currentPlayerGameReports = $currentGameReport->playerGameReports()->get();
+            if ($currentPlayerGameReports->isEmpty()) {
+                return "No player reports found";
             }
 
-            $newPgr->save();
-        }
+            // Undo existing points from cache using current report
+            $this->ladderService->undoCache($currentGameReport);
 
-        // Update game to point to new report
-        $game->game_report_id = $newGameReport->id;
-        $game->save();
+            // Mark ALL reports for this game as no longer the best (handles data integrity issues)
+            \App\Models\GameReport::where('game_id', $game->id)
+                ->update(['best_report' => false]);
 
-        // Determine ladder type and call appropriate award method
-        $apiLadderController = new \App\Http\Controllers\ApiLadderController();
+            // Create new manual game report (preserves original data)
+            $newGameReport = new \App\Models\GameReport();
+            $newGameReport->game_id = $currentGameReport->game_id;
+            $newGameReport->player_id = $currentGameReport->player_id;
+            $newGameReport->best_report = true;
+            $newGameReport->manual_report = true; // Mark as admin-generated
+            $newGameReport->duration = $currentGameReport->duration;
+            $newGameReport->valid = $currentGameReport->valid;
+            $newGameReport->finished = $currentGameReport->finished;
+            $newGameReport->fps = $currentGameReport->fps;
+            $newGameReport->oos = $currentGameReport->oos;
+            $newGameReport->pings_sent = $currentGameReport->pings_sent;
+            $newGameReport->pings_received = $currentGameReport->pings_received;
+            $newGameReport->clan_id = $currentGameReport->clan_id;
+            $newGameReport->save();
 
-        if ($history->ladder->ladder_type == \App\Models\Ladder::CLAN_MATCH)
-        {
-            $status = $apiLadderController->awardClanPoints($newGameReport, $history);
-        }
-        else if ($history->ladder->ladder_type == \App\Models\Ladder::TWO_VS_TWO)
-        {
-            $status = $apiLadderController->awardTeamPoints($newGameReport, $history);
-        }
-        else // 1vs1
-        {
-            $status = $apiLadderController->awardPlayerPoints($newGameReport, $history);
-        }
+            // Detect if this is a 1v1 player override (format: "player_123") or team override (format: "A", "B", etc)
+            $is1v1PlayerOverride = false;
+            $winningPlayerId = null;
+            if ($winningTeam !== null && $winningTeam !== '' && str_starts_with($winningTeam, 'player_'))
+            {
+                $is1v1PlayerOverride = true;
+                $winningPlayerId = (int) str_replace('player_', '', $winningTeam);
+            }
 
-        // Update cache with new points
-        $this->ladderService->updateCache($newGameReport);
+            foreach ($currentPlayerGameReports as $oldPgr)
+            {
+                $newPgr = new \App\Models\PlayerGameReport();
+                $newPgr->game_report_id = $newGameReport->id;
+                $newPgr->game_id = $oldPgr->game_id;
+                $newPgr->player_id = $oldPgr->player_id;
+                $newPgr->local_id = $oldPgr->local_id;
+                $newPgr->local_team_id = $oldPgr->local_team_id;
+                $newPgr->points = 0; // Will be recalculated
+                $newPgr->stats_id = $oldPgr->stats_id;
+                $newPgr->team = $oldPgr->team;
+                $newPgr->spawn = $oldPgr->spawn;
+                $newPgr->clan_id = $oldPgr->clan_id;
+                $newPgr->spectator = $oldPgr->spectator;
 
-        // Log the reprocess action
-        $logMessage = 'Game points reprocessed';
-        if ($is1v1PlayerOverride)
-        {
-            $winningPlayer = \App\Models\Player::find($winningPlayerId);
-            $logMessage .= " with winner override: " . ($winningPlayer ? $winningPlayer->username : "Player #$winningPlayerId");
-        }
-        else if ($winningTeam)
-        {
-            $logMessage .= " with team override: Team $winningTeam";
-        }
+                // If admin selected winner, apply override
+                $hasWinnerOverride = ($is1v1PlayerOverride || ($winningTeam !== null && $winningTeam !== ''));
+                if ($hasWinnerOverride && !$oldPgr->spectator)
+                {
+                    $isWinner = false;
 
-        activity()
-            ->performedOn($game)
-            ->causedBy(auth()->user())
-            ->withProperties([
+                    // For 1v1: match by player_id
+                    if ($is1v1PlayerOverride)
+                    {
+                        $isWinner = ($oldPgr->player_id == $winningPlayerId);
+                    }
+                    // For 2v2/clan: match by team
+                    else
+                    {
+                        $isWinner = ($oldPgr->team === $winningTeam);
+                    }
+
+                    if ($isWinner)
+                    {
+                        $newPgr->won = true;
+                        $newPgr->defeated = false;
+                        $newPgr->draw = false;
+                        $newPgr->disconnected = false;
+                        $newPgr->no_completion = false;
+                        $newPgr->quit = false;
+                    }
+                    else
+                    {
+                        $newPgr->won = false;
+                        $newPgr->defeated = true;
+                        $newPgr->draw = false;
+                        $newPgr->disconnected = false;
+                        $newPgr->no_completion = false;
+                        $newPgr->quit = false;
+                    }
+                }
+                else
+                {
+                    // Keep original outcome
+                    $newPgr->won = $oldPgr->won;
+                    $newPgr->defeated = $oldPgr->defeated;
+                    $newPgr->draw = $oldPgr->draw;
+                    $newPgr->disconnected = $oldPgr->disconnected;
+                    $newPgr->no_completion = $oldPgr->no_completion;
+                    $newPgr->quit = $oldPgr->quit;
+                }
+
+                $newPgr->save();
+            }
+
+            // Update game to point to new report
+            $game->game_report_id = $newGameReport->id;
+            $game->save();
+
+            // Determine ladder type and call appropriate award method
+            $apiLadderController = new \App\Http\Controllers\ApiLadderController();
+
+            if ($history->ladder->ladder_type == \App\Models\Ladder::CLAN_MATCH)
+            {
+                $status = $apiLadderController->awardClanPoints($newGameReport, $history);
+            }
+            else if ($history->ladder->ladder_type == \App\Models\Ladder::TWO_VS_TWO)
+            {
+                $status = $apiLadderController->awardTeamPoints($newGameReport, $history);
+            }
+            else // 1vs1
+            {
+                $status = $apiLadderController->awardPlayerPoints($newGameReport, $history);
+            }
+
+            // Update cache with new points
+            $this->ladderService->updateCache($newGameReport);
+
+            // Log the reprocess action
+            $logMessage = 'Game points reprocessed';
+            if ($is1v1PlayerOverride)
+            {
+                $winningPlayer = \App\Models\Player::find($winningPlayerId);
+                $logMessage .= " with winner override: " . ($winningPlayer ? $winningPlayer->username : "Player #$winningPlayerId");
+            }
+            else if ($winningTeam)
+            {
+                $logMessage .= " with team override: Team $winningTeam";
+            }
+
+            // Use passed auth user or fall back to auth() helper
+            $authUser = $authUser ?? auth()->user();
+            if ($authUser) {
+                activity()
+                    ->performedOn($game)
+                    ->causedBy($authUser)
+                    ->withProperties([
+                        'status' => $status,
+                        'admin' => $userName,
+                        'winning_team_override' => $winningTeam,
+                        'winning_player_id' => $winningPlayerId,
+                        'old_report_id' => $currentGameReport->id,
+                        'new_report_id' => $newGameReport->id
+                    ])
+                    ->log($logMessage);
+            } else {
+                \Log::warning("Activity log skipped - no authenticated user available");
+            }
+
+            \Log::info("=== REPROCESS GAME POINTS END ===", [
                 'status' => $status,
-                'admin' => $userName,
-                'winning_team_override' => $winningTeam,
-                'winning_player_id' => $winningPlayerId,
                 'old_report_id' => $currentGameReport->id,
                 'new_report_id' => $newGameReport->id
-            ])
-            ->log($logMessage);
+            ]);
 
-        \Log::info("=== REPROCESS GAME POINTS END ===", [
-            'status' => $status,
-            'old_report_id' => $currentGameReport->id,
-            'new_report_id' => $newGameReport->id
-        ]);
-
-        return $status;
+            return $status;
+        });
     }
 
     /**

--- a/cncnet-api/app/Http/Services/StatsService.php
+++ b/cncnet-api/app/Http/Services/StatsService.php
@@ -94,13 +94,17 @@ class StatsService
     private function getFactionResults($player, $history, $from, $to)
     {
         // Use single query with aggregation instead of N+1 loop
+        // Use points > 0 instead of won = 1 because the 'won' column is set from client stats dump
+        // before server processes team logic. For 2v2, when server can't determine clear winner
+        // (e.g., ambiguous outcomes, mutual disconnects), it sets points=0 but doesn't update won flag.
+        // Using points > 0 ensures consistency with player stats and reflects server's final decision.
         $results = $player->playerGames()
             ->where("ladder_history_id", $history->id)
             ->whereBetween("player_game_reports.created_at", [$from, $to])
             ->selectRaw('
                 sid,
-                SUM(CASE WHEN won = 1 THEN 1 ELSE 0 END) as won,
-                SUM(CASE WHEN won = 0 THEN 1 ELSE 0 END) as lost,
+                SUM(CASE WHEN points > 0 THEN 1 ELSE 0 END) as won,
+                SUM(CASE WHEN points <= 0 THEN 1 ELSE 0 END) as lost,
                 COUNT(*) as total
             ')
             ->groupBy("sid")
@@ -121,13 +125,17 @@ class StatsService
     private function getFactionResultsForYR($player, $history, $from, $to)
     {
         // Use single query with aggregation instead of N+1 loop
+        // Use points > 0 instead of won = 1 because the 'won' column is set from client stats dump
+        // before server processes team logic. For 2v2, when server can't determine clear winner
+        // (e.g., ambiguous outcomes, mutual disconnects), it sets points=0 but doesn't update won flag.
+        // Using points > 0 ensures consistency with player stats and reflects server's final decision.
         $results = $player->playerGames()
             ->where("ladder_history_id", $history->id)
             ->whereBetween("player_game_reports.created_at", [$from, $to])
             ->selectRaw('
                 cty,
-                SUM(CASE WHEN won = 1 THEN 1 ELSE 0 END) as won,
-                SUM(CASE WHEN won = 0 THEN 1 ELSE 0 END) as lost,
+                SUM(CASE WHEN points > 0 THEN 1 ELSE 0 END) as won,
+                SUM(CASE WHEN points <= 0 THEN 1 ELSE 0 END) as lost,
                 COUNT(*) as total
             ')
             ->groupBy("cty")

--- a/cncnet-api/app/Models/Clan.php
+++ b/cncnet-api/app/Models/Clan.php
@@ -167,6 +167,10 @@ class Clan extends Model
 
     public function averageFPS($history)
     {
+        // Filter FPS to 25-60 range to exclude outliers:
+        // - Below 25: likely game crashes, instant disconnects, or corrupted data
+        // - Above 60: spawner bug
+        // This range represents legitimate gameplay on period-accurate hardware
         return $this->clanGames()
             ->where('ladder_history_id', '=', $history->id)
             ->where('fps', '>', 25)

--- a/cncnet-api/app/Models/Clan.php
+++ b/cncnet-api/app/Models/Clan.php
@@ -167,11 +167,11 @@ class Clan extends Model
 
     public function averageFPS($history)
     {
-        $count = $this->clanGames()->where('ladder_history_id', '=', $history->id)->where('fps', '>', 25)->count();
-        $total = $this->clanGames()->where('ladder_history_id', '=', $history->id)->where('fps', '>', 25)->sum('fps');
-        if ($count != 0)
-            return $total / $count;
-        return 0;
+        return $this->clanGames()
+            ->where('ladder_history_id', '=', $history->id)
+            ->where('fps', '>', 25)
+            ->where('fps', '<=', 60)
+            ->avg('fps') ?? 0;
     }
 
     public function points($history)

--- a/cncnet-api/app/Models/GameReport.php
+++ b/cncnet-api/app/Models/GameReport.php
@@ -3,11 +3,32 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
 
 class GameReport extends Model
 {
+    use LogsActivity;
+
     protected $table = 'game_reports';
     protected $fillable = ['game_id', 'player_id', 'best_report', 'manual_report', 'duration', 'valid', 'fps', 'oos', 'created_at'];
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly(['game_id', 'player_id', 'best_report', 'manual_report', 'duration', 'valid', 'finished', 'fps', 'oos'])
+            ->logOnlyDirty()
+            ->dontSubmitEmptyLogs()
+            // Only log admin manual actions, not routine game processing
+            ->dontLogIfAttributesChangedOnly(['created_at', 'updated_at'])
+            ->useLogName('admin');
+    }
+
+    // Only log when manually created by admin (reprocess, wash, etc)
+    public function shouldLogActivity(): bool
+    {
+        return $this->manual_report === true;
+    }
 
     public function getPointReportByClan($clanId)
     {

--- a/cncnet-api/app/Models/Player.php
+++ b/cncnet-api/app/Models/Player.php
@@ -152,11 +152,11 @@ class Player extends Model
 
     public function averageFPS($history)
     {
-        $count = $this->playerGames()->where('ladder_history_id', '=', $history->id)->where('fps', '>', 25)->count();
-        $total = $this->playerGames()->where('ladder_history_id', '=', $history->id)->where('fps', '>', 25)->sum('fps');
-        if ($count != 0)
-            return $total / $count;
-        return 0;
+        return $this->playerGames()
+            ->where('ladder_history_id', '=', $history->id)
+            ->where('fps', '>', 25)
+            ->where('fps', '<=', 60)
+            ->avg('fps') ?? 0;
     }
 
     public function sideUsage($history)

--- a/cncnet-api/app/Models/Player.php
+++ b/cncnet-api/app/Models/Player.php
@@ -152,6 +152,10 @@ class Player extends Model
 
     public function averageFPS($history)
     {
+        // Filter FPS to 25-60 range to exclude outliers:
+        // - Below 25: likely game crashes, instant disconnects, or corrupted data
+        // - Above 60: spawner bug
+        // This range represents legitimate gameplay on period-accurate hardware
         return $this->playerGames()
             ->where('ladder_history_id', '=', $history->id)
             ->where('fps', '>', 25)

--- a/cncnet-api/app/Models/PlayerGameReport.php
+++ b/cncnet-api/app/Models/PlayerGameReport.php
@@ -3,9 +3,13 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
 
 class PlayerGameReport extends Model
 {
+    use LogsActivity;
+
     // This is a report of disputable information about a game. Undisputed information is stored in the games table
     protected $fillable = [
         'game_id',
@@ -26,6 +30,23 @@ class PlayerGameReport extends Model
         'created_at',
         'updated_at'
     ];
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly(['player_id', 'points', 'won', 'defeated', 'draw', 'disconnected', 'quit', 'no_completion', 'team', 'clan_id'])
+            ->logOnlyDirty()
+            ->dontSubmitEmptyLogs()
+            // Only log admin manual actions, not routine game processing
+            ->dontLogIfAttributesChangedOnly(['created_at', 'updated_at'])
+            ->useLogName('admin');
+    }
+
+    // Only log when part of manual report (admin reprocess, wash, etc)
+    public function shouldLogActivity(): bool
+    {
+        return $this->gameReport && $this->gameReport->manual_report === true;
+    }
 
     public function player()
     {

--- a/cncnet-api/resources/views/admin/audit-log.blade.php
+++ b/cncnet-api/resources/views/admin/audit-log.blade.php
@@ -9,8 +9,11 @@
                 <select name="model_type" id="model_type" class="form-control">
                     <option value="">All</option>
                     <option value="App\Models\Ban" @if(request('model_type')=='App\Models\Ban' ) selected @endif>Ban</option>
+                    <option value="App\Models\Game" @if(request('model_type')=='App\Models\Game' ) selected @endif>Game</option>
+                    <option value="App\Models\GameReport" @if(request('model_type')=='App\Models\GameReport' ) selected @endif>GameReport</option>
                     <option value="App\Models\Map" @if(request('model_type')=='App\Models\Map' ) selected @endif>Map</option>
                     <option value="App\Models\MapPool" @if(request('model_type')=='App\Models\MapPool' ) selected @endif>MapPool</option>
+                    <option value="App\Models\PlayerGameReport" @if(request('model_type')=='App\Models\PlayerGameReport' ) selected @endif>PlayerGameReport</option>
                     <option value="App\Models\QmLadderRules" @if(request('model_type')=='App\Models\QmLadderRules' ) selected @endif>QmLadderRules</option>
                     <option value="App\Models\QmMap" @if(request('model_type')=='App\Models\QmMap' ) selected @endif>QmMap</option>
                     <option value="App\Models\SpawnOptionValue" @if(request('model_type')=='App\Models\SpawnOptionValue' ) selected @endif>SpawnOptionValue</option>
@@ -40,6 +43,7 @@
                 <th>Event</th>
                 <th>Model ID</th>
                 <th>User</th>
+                <th>Description</th>
                 <th>Changes</th>
             </tr>
         </thead>
@@ -60,22 +64,56 @@
                     System
                     @endif
                 </td>
-                    <td>
-                        @if($activity->properties && isset($activity->properties['attributes']))
-                            <strong>New:</strong>
-                            <pre>{{ json_encode($activity->properties['attributes'], JSON_PRETTY_PRINT) }}</pre>
-                            @if(isset($activity->properties['old']))
-                                <strong>Old:</strong>
-                                <pre>{{ json_encode($activity->properties['old'], JSON_PRETTY_PRINT) }}</pre>
-                            @endif
-                        @else
-                            <em>No changes</em>
+                <td>
+                    @if($activity->description)
+                        <strong>{{ $activity->description }}</strong>
+                    @else
+                        <em>-</em>
+                    @endif
+                </td>
+                <td>
+                    @if($activity->properties && isset($activity->properties['changes_summary']))
+                        {{-- Custom reprocess format --}}
+                        <div class="mb-2">
+                            <strong>Changes:</strong>
+                            <ul class="mb-0">
+                                @foreach($activity->properties['changes_summary'] as $change)
+                                    <li>{{ $change }}</li>
+                                @endforeach
+                            </ul>
+                        </div>
+                        @if(isset($activity->properties['status']))
+                            <small class="text-muted">Status: {{ $activity->properties['status'] }}</small>
                         @endif
-                    </td>
+                        <details class="mt-2">
+                            <summary style="cursor: pointer;" class="text-primary">Show full details</summary>
+                            <div class="mt-2">
+                                @if(isset($activity->properties['before_state']))
+                                    <strong>Before:</strong>
+                                    <pre style="font-size: 0.8rem; max-height: 300px; overflow-y: auto;">{{ json_encode($activity->properties['before_state'], JSON_PRETTY_PRINT) }}</pre>
+                                @endif
+                                @if(isset($activity->properties['after_state']))
+                                    <strong>After:</strong>
+                                    <pre style="font-size: 0.8rem; max-height: 300px; overflow-y: auto;">{{ json_encode($activity->properties['after_state'], JSON_PRETTY_PRINT) }}</pre>
+                                @endif
+                            </div>
+                        </details>
+                    @elseif($activity->properties && isset($activity->properties['attributes']))
+                        {{-- Standard Spatie format --}}
+                        <strong>New:</strong>
+                        <pre style="font-size: 0.8rem; max-height: 300px; overflow-y: auto;">{{ json_encode($activity->properties['attributes'], JSON_PRETTY_PRINT) }}</pre>
+                        @if(isset($activity->properties['old']))
+                            <strong>Old:</strong>
+                            <pre style="font-size: 0.8rem; max-height: 300px; overflow-y: auto;">{{ json_encode($activity->properties['old'], JSON_PRETTY_PRINT) }}</pre>
+                        @endif
+                    @else
+                        <em>No changes</em>
+                    @endif
+                </td>
             </tr>
             @empty
             <tr>
-                <td colspan="6">No audit events found.</td>
+                <td colspan="7">No audit events found.</td>
             </tr>
             @endforelse
         </tbody>

--- a/cncnet-api/resources/views/ladders/game/_admin-game-tools.blade.php
+++ b/cncnet-api/resources/views/ladders/game/_admin-game-tools.blade.php
@@ -202,7 +202,7 @@
                             </div>
 
                             <div class="d-grid">
-                                <button type="submit" class="btn btn-warning btn-lg shadow" style="font-weight: bold; border: 3px solid #fff;">
+                                <button type="submit" class="btn btn-warning btn-lg shadow" style="font-weight: bold; border: 3px solid #fff;" onclick="return confirm('Reprocess this game? Points will be recalculated using current ladder rules.');">
                                     <i class="fa fa-cogs fa-fw"></i> Reprocess Points
                                 </button>
                             </div>

--- a/cncnet-api/resources/views/ladders/game/_admin-game-tools.blade.php
+++ b/cncnet-api/resources/views/ladders/game/_admin-game-tools.blade.php
@@ -142,11 +142,77 @@
             @endforeach
 
             @if (!(isset($hasWash) && $hasWash) && $userIsMod)
-                <form action="/admin/moderate/{{ $history->ladder->id }}/games/wash" class="text-center" method="POST">
-                    <input type="hidden" name="_token" value="{{ csrf_token() }}">
-                    <input name="game_id" type="hidden" value="{{ $game->id }}" />
-                    <button type="submit" class="btn btn-md btn-danger">Wash</button>
-                </form>
+                <div class="d-flex justify-content-center gap-3 mt-4 mb-4">
+                    <form action="/admin/moderate/{{ $history->ladder->id }}/games/wash" method="POST">
+                        <input type="hidden" name="_token" value="{{ csrf_token() }}">
+                        <input name="game_id" type="hidden" value="{{ $game->id }}" />
+                        <button type="submit" class="btn btn-lg shadow-sm" style="background-color: #ffc107; color: #000; font-weight: bold; border: none;">
+                            <i class="fa fa-refresh fa-fw"></i> Wash Game
+                        </button>
+                    </form>
+                </div>
+            @endif
+
+            @if ($userIsMod)
+                <div class="card shadow-lg border-0 mt-4 mb-4 mx-auto" style="max-width: 600px; border-radius: 12px; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);">
+                    <div class="card-body p-4">
+                        <form action="/admin/moderate/{{ $history->ladder->id }}/games/reprocess" method="POST">
+                            @csrf
+                            <input name="game_id" type="hidden" value="{{ $game->id }}" />
+
+                            <h5 class="text-white text-center mb-3">
+                                <i class="fa fa-refresh fa-fw"></i> Reprocess Game Points
+                            </h5>
+
+                            <div class="mb-3">
+                                @php
+                                    $is1v1 = $history->ladder->ladder_type == \App\Models\Ladder::ONE_VS_ONE;
+                                    $playerGameReports = $gameReport->playerGameReports()->where('spectator', 0)->get();
+                                @endphp
+
+                                <label for="winning_team" class="form-label text-white">
+                                    <strong>{{ $is1v1 ? 'Select Winner (Optional)' : 'Select Winning Team (Optional)' }}</strong>
+                                </label>
+
+                                <select name="winning_team" id="winning_team" class="form-select form-select-lg">
+                                    <option value="">Keep current outcome</option>
+
+                                    @if ($is1v1)
+                                        {{-- For 1v1, use player_id as identifier since team field is null --}}
+                                        @foreach ($playerGameReports as $pgr)
+                                            <option value="player_{{ $pgr->player_id }}">{{ $pgr->player->username }}</option>
+                                        @endforeach
+                                    @else
+                                        {{-- For 2v2/clan, show teams with player names --}}
+                                        @php
+                                            $teamPlayers = $playerGameReports->groupBy('team');
+                                        @endphp
+                                        @foreach ($teamPlayers as $team => $players)
+                                            @php
+                                                $playerNames = $players->pluck('player.username')->implode(', ');
+                                            @endphp
+                                            <option value="{{ $team }}">Team {{ $team }}: {{ $playerNames }}</option>
+                                        @endforeach
+                                    @endif
+                                </select>
+
+                                <small class="text-white-50 d-block mt-2">
+                                    {{ $is1v1 ? 'Choose a player to set as winner, or leave default to use existing outcome' : 'Choose a team to override the winner, or leave default to use existing outcome' }}
+                                </small>
+                            </div>
+
+                            <div class="d-grid">
+                                <button type="submit" class="btn btn-warning btn-lg shadow" style="font-weight: bold; border: 3px solid #fff;">
+                                    <i class="fa fa-cogs fa-fw"></i> Reprocess Points
+                                </button>
+                            </div>
+
+                            <small class="text-white-50 d-block mt-3 text-center">
+                                Recalculates points using current ladder rules. Use team override if system chose wrong winner.
+                            </small>
+                        </form>
+                    </div>
+                </div>
             @endif
 
             <div class="game-details text-center">

--- a/cncnet-api/resources/views/ladders/game/_admin-game-tools.blade.php
+++ b/cncnet-api/resources/views/ladders/game/_admin-game-tools.blade.php
@@ -164,6 +164,16 @@
                                 <i class="fa fa-refresh fa-fw"></i> Reprocess Game Points
                             </h5>
 
+                            @if ($errors->any())
+                                <div class="alert alert-danger" role="alert">
+                                    <ul class="mb-0">
+                                        @foreach ($errors->all() as $error)
+                                            <li>{{ $error }}</li>
+                                        @endforeach
+                                    </ul>
+                                </div>
+                            @endif
+
                             <div class="mb-3">
                                 @php
                                     $is1v1 = $history->ladder->ladder_type == \App\Models\Ladder::ONE_VS_ONE;

--- a/cncnet-api/routes/web.php
+++ b/cncnet-api/routes/web.php
@@ -195,6 +195,7 @@ Route::group(['prefix' => 'admin'], function ()
             Route::post('/games/{cncnetGame}/delete', [AdminController::class, 'deleteGame']);
             Route::post('/games/switch', [AdminController::class, 'switchGameReport']);
             Route::post('/games/wash', [AdminController::class, 'washGame']);
+            Route::post('/games/reprocess', [AdminController::class, 'reprocessGamePoints'])->name('admin.games.reprocess');
             Route::post('/games/fix-points', [AdminController::class, 'fixPoints']);
 
             Route::get('/player/{playerId}', [AdminController::class, 'getLadderPlayer']);


### PR DESCRIPTION
## Summary

Adds admin capability to reprocess game points with optional winner override, plus several stat calculation fixes and optimizations.

## Changes

### 1. Average FPS Optimization & Filtering
- **Player.php, Clan.php**: Optimized `averageFPS()` from two queries to single `AVG()` query
- Added FPS filter: only count games with fps between 25-60 (excludes outliers)

### 2. Faction Stats Consistency Fix  
- **StatsService.php**: Changed `getFactionResults()` and `getFactionResultsForYR()` to use `points > 0` instead of `won = 1`
- Fixes inconsistency where faction stats showed different win counts than player stats
- Root cause: `won` flag set from client before server processes 2v2 team logic

### 3. FPS Filter Improvement
- **ApiLadderController.php**: Modified FPS filter in `awardClanPoints()`, `awardTeamPoints()`, `awardPlayerPoints()`
- FPS filter now only applies to games under 2 minutes (prevents instant disconnect abuse)
- Allows legitimate long games with low FPS (e.g., 30-minute game with fps=25)

### 4. Admin Reprocess Game Points Feature
- **AdminService.php**: New `reprocessGamePoints()` method
  - Creates new manual GameReport (preserves original for audit trail)
  - Clones all PlayerGameReport records
  - Optional winner/team override for fixing incorrect outcomes
  - Supports 1v1 (player_id) and 2v2/clan (team) overrides
  - Undoes old points, recalculates with current ladder rules, updates cache
  
- **AdminController.php**: New `reprocessGamePoints()` controller method
- **routes/web.php**: Added `/admin/moderate/{ladderId}/games/reprocess` route
- **_admin-game-tools.blade.php**: Purple gradient UI card with:
  - Dropdown for winner/team selection (adaptive for 1v1 vs 2v2/clan)
  - "Reprocess Points" button
  - Yellow "Wash Game" button styling improvement

## Use Cases

- Fix games where FPS filter incorrectly rejected valid matches
- Override winner when game report outcome is wrong
- Recalculate points after ladder rule changes
- Preserve audit trail with manual report generation

## Testing

Tested on:
- 1v1 game with player override ✅
- 2v2 game with team override ✅
- Game 1137572 (30-minute match that previously awarded 0 points) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)