### PR TITLE
Fix missing spawn overlay on game detail pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,6 +326,65 @@ Separate cron-based ELO computation system:
 - **Development Vite**: http://localhost:5173
 - **Production**: https://ladder.cncnet.org
 
+## Known Issues & Workarounds
+
+### Hash-based Map Relationship Limitations
+
+The `Game->map()` relationship uses hash matching instead of foreign keys:
+```php
+// Game.php line 51
+return $this->belongsTo(Map::class, 'hash', 'hash');
+```
+
+**Problems:**
+- Nested eager loading fails: `'map.mapHeaders.waypoints'` marks relation as loaded but returns null
+- Multiple maps can have same hash → relationship returns arbitrary match
+- No guarantee correct map selected when duplicates exist
+
+**Solution:**
+- Prefer `game->qmMap->map` (proper FK chain) when available (games since June 2026)
+- Fallback to hash-based with manual mapHeaders check for older games
+- See `GetGameDetailAction.php` lines 278-290 for reference pattern
+
+### Map Selection Pattern
+
+Always use this pattern when displaying map data with mapHeaders:
+
+```php
+// Select map: prefer qmMap (FK chain), fallback to hash-based
+$map = $game->qmMap?->map ?? $game->map;
+
+// Handle duplicate hash collision - find map with mapHeaders if current doesn't have it
+if ($map && !$map->mapHeaders) {
+    $alternateMap = \App\Models\Map::where('hash', $map->hash)
+        ->whereHas('mapHeaders')
+        ->with('mapHeaders.waypoints')
+        ->first();
+
+    if ($alternateMap) {
+        $map = $alternateMap;
+    }
+}
+```
+
+**Don't** compute map selection in views - do it in controller/action layer for single source of truth.
+
+### Running Laravel Commands in Development
+
+**IMPORTANT**: All Laravel/Artisan commands must run inside Docker container:
+
+```bash
+# ✓ CORRECT - via docker exec
+docker exec dev_cncnet_ladder_app php artisan tinker
+docker exec dev_cncnet_ladder_app php artisan migrate
+
+# ✗ WRONG - will fail (no PHP/DB access outside container)
+php artisan tinker
+cd cncnet-api && php artisan tinker
+```
+
+This applies to: artisan, composer, tinker, migrations, queue commands, etc.
+
 ## Troubleshooting
 
 **"No supported encrypter found"**:

--- a/cncnet-api/app/Actions/Game/GetGameDetailAction.php
+++ b/cncnet-api/app/Actions/Game/GetGameDetailAction.php
@@ -275,6 +275,22 @@ class GetGameDetailAction
             }
         }
 
+        // Select correct map: prefer qmMap->map (proper FK), fallback to game->map (hash-based)
+        $map = $game->qmMap?->map ?? $game->map;
+
+        // Fix: hash-based map relation can match multiple maps (duplicate hashes)
+        // If current map has no mapHeaders, try finding another map with same hash that has mapHeaders
+        if ($map && !$map->mapHeaders) {
+            $alternateMap = \App\Models\Map::where('hash', $map->hash)
+                ->whereHas('mapHeaders')
+                ->with('mapHeaders.waypoints')
+                ->first();
+
+            if ($alternateMap) {
+                $map = $alternateMap;
+            }
+        }
+
         return [
             'game' => $game,
             'gameReport' => $gameReport,
@@ -294,7 +310,7 @@ class GetGameDetailAction
             'showBothZeroFix' => $showBothZeroFix,
             'fixedPointsPreview' => $fixedPointsPreview,
             // Pre-computed data to avoid queries in views
-            'map' => $game->map,  // Already eager loaded
+            'map' => $map,
             'gameAbbreviation' => $history->ladder->abbreviation,  // Use property, not method
         ];
     }
@@ -339,6 +355,22 @@ class GetGameDetailAction
         // Get tunnels from connection stats
         $tunnels = TunnelHelper::getTunnelsFromStats($qmConnectionStats);
 
+        // Select correct map: prefer qmMap->map (proper FK), fallback to game->map (hash-based)
+        $map = $game->qmMap?->map ?? $game->map;
+
+        // Fix: hash-based map relation can match multiple maps (duplicate hashes)
+        // If current map has no mapHeaders, try finding another map with same hash that has mapHeaders
+        if ($map && !$map->mapHeaders) {
+            $alternateMap = \App\Models\Map::where('hash', $map->hash)
+                ->whereHas('mapHeaders')
+                ->with('mapHeaders.waypoints')
+                ->first();
+
+            if ($alternateMap) {
+                $map = $alternateMap;
+            }
+        }
+
         return [
             'game' => $game,
             'gameReport' => $gameReport,
@@ -360,7 +392,7 @@ class GetGameDetailAction
             'showBothZeroFix' => $showBothZeroFix,
             'fixedPointsPreview' => $fixedPointsPreview,
             // Pre-computed data to avoid queries in views
-            'map' => $game->map,  // Already eager loaded
+            'map' => $map,
             'gameAbbreviation' => $history->ladder->abbreviation,  // Use property, not method
         ];
     }

--- a/cncnet-api/app/Actions/Game/GetGameDetailAction.php
+++ b/cncnet-api/app/Actions/Game/GetGameDetailAction.php
@@ -12,6 +12,7 @@ use App\Models\Game;
 use App\Models\GameReport;
 use App\Models\Ladder;
 use App\Models\LadderHistory;
+use App\Models\Map;
 use Illuminate\Contracts\Auth\Authenticatable;
 
 class GetGameDetailAction
@@ -275,21 +276,7 @@ class GetGameDetailAction
             }
         }
 
-        // Select correct map: prefer qmMap->map (proper FK), fallback to game->map (hash-based)
-        $map = $game->qmMap?->map ?? $game->map;
-
-        // Fix: hash-based map relation can match multiple maps (duplicate hashes)
-        // If current map has no mapHeaders, try finding another map with same hash that has mapHeaders
-        if ($map && !$map->mapHeaders) {
-            $alternateMap = \App\Models\Map::where('hash', $map->hash)
-                ->whereHas('mapHeaders')
-                ->with('mapHeaders.waypoints')
-                ->first();
-
-            if ($alternateMap) {
-                $map = $alternateMap;
-            }
-        }
+        $map = $this->resolveMapWithHeaders($game);
 
         return [
             'game' => $game,
@@ -355,21 +342,7 @@ class GetGameDetailAction
         // Get tunnels from connection stats
         $tunnels = TunnelHelper::getTunnelsFromStats($qmConnectionStats);
 
-        // Select correct map: prefer qmMap->map (proper FK), fallback to game->map (hash-based)
-        $map = $game->qmMap?->map ?? $game->map;
-
-        // Fix: hash-based map relation can match multiple maps (duplicate hashes)
-        // If current map has no mapHeaders, try finding another map with same hash that has mapHeaders
-        if ($map && !$map->mapHeaders) {
-            $alternateMap = \App\Models\Map::where('hash', $map->hash)
-                ->whereHas('mapHeaders')
-                ->with('mapHeaders.waypoints')
-                ->first();
-
-            if ($alternateMap) {
-                $map = $alternateMap;
-            }
-        }
+        $map = $this->resolveMapWithHeaders($game);
 
         return [
             'game' => $game,
@@ -395,5 +368,35 @@ class GetGameDetailAction
             'map' => $map,
             'gameAbbreviation' => $history->ladder->abbreviation,  // Use property, not method
         ];
+    }
+
+    /**
+     * Resolve map with mapHeaders, handling hash collisions
+     *
+     * Prefers qmMap->map (proper FK chain), falls back to game->map (hash-based).
+     * When hash-based map has duplicate records, finds one with mapHeaders populated.
+     *
+     * @param Game $game
+     * @return Map|null
+     */
+    private function resolveMapWithHeaders(Game $game): ?Map
+    {
+        // Select correct map: prefer qmMap->map (proper FK), fallback to game->map (hash-based)
+        $map = $game->qmMap?->map ?? $game->map;
+
+        // Fix: hash-based map relation can match multiple maps (duplicate hashes)
+        // If current map has no mapHeaders, try finding another map with same hash that has mapHeaders
+        if ($map && !$map->mapHeaders) {
+            $alternateMap = Map::where('hash', $map->hash)
+                ->whereHas('mapHeaders')
+                ->with('mapHeaders.waypoints')
+                ->first();
+
+            if ($alternateMap) {
+                return $alternateMap;
+            }
+        }
+
+        return $map;
     }
 }

--- a/cncnet-api/app/Http/Services/GameReportService.php
+++ b/cncnet-api/app/Http/Services/GameReportService.php
@@ -41,11 +41,11 @@ class GameReportService
             'report.game.qmMatch.map', // Needed for map preview (legacy, backward compatibility)
 
             // QM Map data (direct relationship, persists after qm_matches pruning)
-            'qmMap.map',
+            'qmMap.map', // Note: mapHeaders loaded manually in action due to Laravel eager loading limitations
 
             // QM Match data (legacy, for backward compatibility)
             'qmMatch.qmConnectionStats',
-            'qmMatch.map',
+            'qmMatch.map', // Note: mapHeaders loaded manually in action
         ];
 
         // Add moderator-specific eager loading

--- a/cncnet-api/resources/views/ladders/game/_map-preview-with-players.blade.php
+++ b/cncnet-api/resources/views/ladders/game/_map-preview-with-players.blade.php
@@ -1,8 +1,7 @@
 @php
     $mapPreview = null;
     try {
-        $mapObject = $gameReport->game->qmMap?->map ?? $gameReport->game->map;
-        $mapPreview = \App\Helpers\SiteHelper::getMapPreviewUrl($history, $mapObject, $gameReport->game);
+        $mapPreview = \App\Helpers\SiteHelper::getMapPreviewUrl($history, $map, $gameReport->game);
         if (isset($mapPreview) && !empty($mapPreview)) {
             $mapPreviewSize = getimagesize($mapPreview);
 


### PR DESCRIPTION
## Summary

Fixes spawn position overlay not appearing on some game detail pages (e.g., ra2-2v2 games).

## Root Cause

Two issues caused the bug:

1. **Variable mismatch in view**: View template calculated `$mapObject` for preview URL (line 4) but used `$map` from controller for spawn calculations (lines 12-15, 58), causing inconsistency
2. **Hash collision with duplicate maps**: Hash-based `game->map` relationship could match multiple Map records with same hash. When duplicates existed, Laravel sometimes returned map without `mapHeaders` relation populated

## Changes

### GetGameDetailAction.php
- Moved map selection logic from view to action (proper separation of concerns)
- Added logic to select `qmMap->map` if available (proper FK chain), falls back to `game->map` (hash-based)
- Added fallback when map has no mapHeaders: searches for alternate map with same hash that has mapHeaders populated
- Ensures mapHeaders always loaded for spawn overlay rendering

### _map-preview-with-players.blade.php
- Removed duplicate `$mapObject` calculation
- Simplified to use single `$map` variable from controller throughout
- View now purely renders, no business logic

### GameReportService.php
- Updated comments for clarity on eager loading limitations

## Testing

Verified spawn overlay now appears on:
- RA2 2v2 games (previously broken)
- Blitz 2v2 games (continued working)
- Games with hash collisions (duplicate map records)

## Technical Notes

Issue introduced in PR #516 which added `$mapObject` calculation but didn't fully update spawn overlay logic to use it consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)