### PR TITLE
Initial replay support

### DIFF
--- a/cncnet-api/app/Actions/Game/GetGameDetailAction.php
+++ b/cncnet-api/app/Actions/Game/GetGameDetailAction.php
@@ -221,6 +221,12 @@ class GetGameDetailAction
                 ->where('game_id', $pgr->game_id)
                 ->first();
 
+            // Pre-compute replay (uses eager-loaded gameReplays collection). Each player has their
+            // own file - the replay records that player's viewport and unit selection.
+            $pgr->playerReplay = $pgr->player->gameReplays
+                ->where('game_id', $pgr->game_id)
+                ->first();
+
             // Pre-compute faction for display (fixes redundant Stats2 query in views)
             if ($pgr->stats) {
                 $pgr->playerFaction = $pgr->stats->faction($history->ladder, $pgr->stats->cty);

--- a/cncnet-api/app/Http/Controllers/ApiReplayController.php
+++ b/cncnet-api/app/Http/Controllers/ApiReplayController.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Services\ReplayService;
+use App\Models\Game;
+use App\Models\Ladder;
+use App\Models\Player;
+use App\Models\PlayerGameReport;
+use App\Models\QmMatchPlayer;
+use Exception;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+class ApiReplayController extends Controller
+{
+    private $replayService;
+
+    public function __construct()
+    {
+        $this->replayService = new ReplayService();
+    }
+
+    /**
+     * Accepts a replay recorded by the Quick Match spawner for a finished game.
+     *
+     * A replay is only accepted when the authenticated user owns the player it is being uploaded
+     * for, and that player actually took part in the game. Without both checks any authenticated
+     * user could attach arbitrary files to any game.
+     */
+    public function uploadReplay(Request $request, $ladderId, $gameId, $playerId)
+    {
+        $user = $request->user();
+
+        try
+        {
+            $request->validate([
+                // max: is in kilobytes.
+                'file' => 'required|file|max:' . ((int) config('replays.max_upload_mb') * 1024),
+            ]);
+
+            $game = Game::find($gameId);
+            if ($game === null)
+            {
+                return response()->json(['message' => 'Game not found'], 404);
+            }
+
+            // games has no ladder_id column - despite one being listed in the model's $fillable.
+            // The ladder is reached through the monthly ladder_history row instead.
+            $history = $game->ladderHistory;
+            if ($history === null || (int) $history->ladder_id !== (int) $ladderId)
+            {
+                return response()->json(['message' => 'Game does not belong to this ladder'], 404);
+            }
+
+            $ladder = Ladder::find($ladderId);
+            $rules = $ladder ? $ladder->qmLadderRules : null;
+            if ($rules !== null && !$rules->enable_replays)
+            {
+                // The ladder has replays switched off; treat a straggling upload as a no-op rather
+                // than storing a file nobody asked for.
+                return response()->json(['message' => 'Replays are not enabled for this ladder'], 403);
+            }
+
+            $player = Player::find($playerId);
+            if ($player === null)
+            {
+                return response()->json(['message' => 'Player not found'], 404);
+            }
+
+            // The uploader must own this player account.
+            if ((int) $player->user_id !== (int) $user->id)
+            {
+                Log::warning("ApiReplayController: user {$user->id} tried to upload a replay as player {$playerId}.");
+                return response()->json(['message' => 'You may only upload replays for your own account'], 403);
+            }
+
+            // ... and must have actually played in this game.
+            $participated = PlayerGameReport::where('game_id', $game->id)
+                ->where('player_id', $player->id)
+                ->exists();
+
+            if (!$participated && $game->qm_match_id)
+            {
+                // player_game_reports is written by SaveLadderResultJob, which runs on a queue, so
+                // it usually does not exist yet when a client uploads immediately after the match.
+                // Whoever finishes first would otherwise always be rejected. qm_match_players is
+                // written when the match is created, so it is available straight away and is just
+                // as authoritative about who was actually in the game.
+                $participated = QmMatchPlayer::where('qm_match_id', $game->qm_match_id)
+                    ->where('player_id', $player->id)
+                    ->exists();
+            }
+
+            if (!$participated)
+            {
+                Log::warning("ApiReplayController: player {$playerId} is not part of game {$gameId}.");
+                return response()->json(['message' => 'Player did not participate in this game'], 403);
+            }
+
+            $replay = $this->replayService->storeReplay(
+                $game->id,
+                $player->id,
+                $user->id,
+                $request->file('file')
+            );
+
+            return response()->json([
+                'message'   => 'Replay uploaded successfully',
+                'game_id'   => $game->id,
+                'player_id' => $player->id,
+                'file_size' => $replay->file_size,
+            ], 200);
+        }
+        catch (Exception $ex)
+        {
+            Log::error("ApiReplayController: error uploading replay: " . $ex->getMessage() . " : " . $ex->getTraceAsString());
+        }
+
+        return response()->json(['message' => 'Replay not uploaded'], 400);
+    }
+}

--- a/cncnet-api/app/Http/Controllers/ReplayController.php
+++ b/cncnet-api/app/Http/Controllers/ReplayController.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Services\ReplayService;
+use App\Models\GameReplay;
+use App\Models\Ladder;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+class ReplayController extends Controller
+{
+    private $replayService;
+
+    public function __construct()
+    {
+        $this->replayService = new ReplayService();
+    }
+
+    /**
+     * Serves a stored replay file.
+     *
+     * Replays are held on a private disk and only ever handed out through here, so access can be
+     * restricted. During the beta that means staff only, controlled by the
+     * 'replays.staff_only_downloads' config flag.
+     */
+    public function download(Request $request, $replayId)
+    {
+        $user = $request->user();
+
+        $replay = GameReplay::find($replayId);
+        if ($replay === null)
+        {
+            abort(404);
+        }
+
+        if (config('replays.staff_only_downloads') && !$this->userIsStaff($user, $replay))
+        {
+            Log::warning("ReplayController: user {$user->id} was denied replay {$replayId}.");
+            abort(403);
+        }
+
+        $path = $this->replayService->replayPath($replay);
+        if ($path === null)
+        {
+            // Row exists but the file is gone - most likely evicted by the storage budget.
+            Log::warning("ReplayController: replay {$replayId} has no file on disk.");
+            abort(404);
+        }
+
+        return response()->download($path, $this->replayService->downloadName($replay));
+    }
+
+    /**
+     * Global staff, or a moderator/admin of the ladder the game belongs to.
+     */
+    private function userIsStaff($user, GameReplay $replay): bool
+    {
+        if ($user === null)
+        {
+            return false;
+        }
+
+        if ($user->isModerator())
+        {
+            return true;
+        }
+
+        $game = $replay->game;
+        if ($game === null)
+        {
+            return false;
+        }
+
+        // games has no ladder_id column - the ladder is reached via the monthly ladder_history row.
+        $history = $game->ladderHistory;
+        if ($history === null)
+        {
+            return false;
+        }
+
+        $ladder = Ladder::find($history->ladder_id);
+        if ($ladder === null)
+        {
+            return false;
+        }
+
+        return $user->isLadderMod($ladder) || $user->isLadderAdmin($ladder);
+    }
+}

--- a/cncnet-api/app/Http/Services/AdminService.php
+++ b/cncnet-api/app/Http/Services/AdminService.php
@@ -48,6 +48,7 @@ class AdminService
         $ladderRule->points_per_second = $request->points_per_second;
 
         $ladderRule->show_map_preview = $request->show_map_preview;
+        $ladderRule->enable_replays = $request->enable_replays;
         $ladderRule->wol_k = $request->wol_k;
         $ladderRule->upset_k = $request->upset_k;
         $ladderRule->upset_k_loser_multiplier = $request->upset_k_loser_multiplier;

--- a/cncnet-api/app/Http/Services/GameReportService.php
+++ b/cncnet-api/app/Http/Services/GameReportService.php
@@ -34,6 +34,7 @@ class GameReportService
             'report.playerGameReports.player.user.userSettings',
             'report.playerGameReports.player.clanPlayer.clan',
             'report.playerGameReports.player.gameClips', // For game clips display
+            'report.playerGameReports.player.gameReplays', // For replay download buttons
             'report.playerGameReports.stats.gameObjectCounts.countableGameObject', // CRITICAL: Eliminates N+1 for cameo stats
             'report.playerGameReports.clan',
             'report.playerGameReports.gameReport', // Needed for clan logic in views
@@ -55,6 +56,7 @@ class GameReportService
                 'allReports.playerGameReports.player.user.userSettings',
                 'allReports.playerGameReports.player.clanPlayer.clan',
                 'allReports.playerGameReports.player.gameClips',
+                'allReports.playerGameReports.player.gameReplays',
                 'allReports.playerGameReports.stats.gameObjectCounts.countableGameObject',
                 'allReports.playerGameReports.clan',
                 'allReports.playerGameReports.gameReport',

--- a/cncnet-api/app/Http/Services/QuickMatchSpawnService.php
+++ b/cncnet-api/app/Http/Services/QuickMatchSpawnService.php
@@ -31,7 +31,12 @@ class QuickMatchSpawnService
                 "SpawnLocations" => [],
                 "Settings" => []
             ],
-            "client" => ["show_map_preview" => $ladderRules->show_map_preview]
+            "client" => [
+                "show_map_preview" => $ladderRules->show_map_preview,
+                // Drives both replay recording and which spawner DLL the client injects, so
+                // replays can be switched off server-side without a client update.
+                "enable_replays" => (bool) $ladderRules->enable_replays
+            ]
         ];
 
         srand($qmMatch->seed); // Seed the RNG for possibly random boolean options

--- a/cncnet-api/app/Http/Services/ReplayService.php
+++ b/cncnet-api/app/Http/Services/ReplayService.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace App\Http\Services;
+
+use App\Models\GameReplay;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+class ReplayService
+{
+    private function disk()
+    {
+        return Storage::disk(config('replays.disk'));
+    }
+
+    public function maxUploadBytes(): int
+    {
+        return (int) config('replays.max_upload_mb') * 1024 * 1024;
+    }
+
+    public function maxTotalBytes(): int
+    {
+        return (int) config('replays.max_total_mb') * 1024 * 1024;
+    }
+
+    /**
+     * Total bytes currently accounted for by stored replays.
+     */
+    public function totalStoredBytes(): int
+    {
+        return (int) GameReplay::sum('file_size');
+    }
+
+    /**
+     * Stores an uploaded replay, replacing any existing replay for the same game and player.
+     *
+     * @return GameReplay
+     */
+    public function storeReplay(int $gameId, int $playerId, int $userId, UploadedFile $file): GameReplay
+    {
+        // Randomised name rather than one derived from game/player ids, so replay files cannot be
+        // enumerated if the storage root is ever served directly by mistake. .yrrp is the
+        // extension the client associates with replays.
+        $filename = Str::random(40) . '.yrrp';
+        $directory = config('replays.directory');
+
+        $this->disk()->putFileAs($directory, $file, $filename);
+
+        // A re-upload for the same game and player supersedes the previous file. Remove the old
+        // one from disk first, otherwise it would be orphaned and never counted against budget.
+        $existing = GameReplay::where('game_id', $gameId)->where('player_id', $playerId)->first();
+        if ($existing !== null)
+        {
+            $this->deleteFile($existing);
+        }
+
+        $replay = GameReplay::updateOrCreate(
+            ['game_id' => $gameId, 'player_id' => $playerId],
+            [
+                'user_id'   => $userId,
+                'filename'  => $filename,
+                'file_size' => $file->getSize(),
+            ]
+        );
+
+        $this->enforceStorageBudget();
+
+        return $replay;
+    }
+
+    /**
+     * Deletes oldest-first until stored replays fit within the configured budget.
+     *
+     * Runs after each upload rather than on a schedule, so the budget cannot be exceeded for long
+     * regardless of upload rate.
+     */
+    public function enforceStorageBudget(): void
+    {
+        $budget = $this->maxTotalBytes();
+        if ($budget <= 0)
+        {
+            return;
+        }
+
+        $total = $this->totalStoredBytes();
+        if ($total <= $budget)
+        {
+            return;
+        }
+
+        Log::info("ReplayService: replay storage at {$total} bytes exceeds budget of {$budget} bytes, evicting oldest.");
+
+        // Chunked oldest-first so a large backlog cannot load every row into memory at once.
+        GameReplay::orderBy('created_at', 'asc')->orderBy('id', 'asc')
+            ->chunkById(100, function ($replays) use (&$total, $budget)
+            {
+                foreach ($replays as $replay)
+                {
+                    if ($total <= $budget)
+                    {
+                        return false;
+                    }
+
+                    $total -= (int) $replay->file_size;
+                    $this->deleteFile($replay);
+                    $replay->delete();
+                }
+
+                return true;
+            });
+    }
+
+    /**
+     * Removes a replay's file from disk. The database row is handled separately so that a missing
+     * file never blocks the row being replaced or deleted.
+     */
+    private function deleteFile(GameReplay $replay): void
+    {
+        $path = config('replays.directory') . '/' . $replay->filename;
+
+        try
+        {
+            if ($this->disk()->exists($path))
+            {
+                $this->disk()->delete($path);
+            }
+        }
+        catch (\Exception $ex)
+        {
+            Log::warning("ReplayService: could not delete replay file {$path}: " . $ex->getMessage());
+        }
+    }
+
+    /**
+     * Absolute path of a stored replay, or null when the file is missing.
+     */
+    public function replayPath(GameReplay $replay): ?string
+    {
+        $path = config('replays.directory') . '/' . $replay->filename;
+
+        if (!$this->disk()->exists($path))
+        {
+            return null;
+        }
+
+        return $this->disk()->path($path);
+    }
+
+    /**
+     * Filename offered to the browser. Includes game and player so downloaded files stay
+     * distinguishable once several are saved side by side, and uses the .yrrp extension the
+     * client lists replays by, so a download can be dropped straight into the Replays folder.
+     */
+    public function downloadName(GameReplay $replay): string
+    {
+        $playerName = optional($replay->player)->username ?? "player{$replay->player_id}";
+        $safeName = preg_replace('/[^A-Za-z0-9_\-]/', '_', $playerName);
+
+        return "replay_game{$replay->game_id}_{$safeName}.yrrp";
+    }
+}

--- a/cncnet-api/app/Models/GameReplay.php
+++ b/cncnet-api/app/Models/GameReplay.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class GameReplay extends Model
+{
+    protected $table = 'game_replays';
+
+    protected $fillable = [
+        'game_id',
+        'player_id',
+        'user_id',
+        'filename',
+        'file_size',
+    ];
+
+    public function game()
+    {
+        return $this->belongsTo(Game::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function player()
+    {
+        return $this->belongsTo(Player::class);
+    }
+}

--- a/cncnet-api/app/Models/Player.php
+++ b/cncnet-api/app/Models/Player.php
@@ -296,6 +296,11 @@ class Player extends Model
         return $this->hasMany(GameClip::class);
     }
 
+    public function gameReplays()
+    {
+        return $this->hasMany(GameReplay::class);
+    }
+
     public function unSeenAlerts()
     {
         return $this->hasMany(PlayerAlert::class)->whereNull('seen_at')->where('expires_at', '>', Carbon::now());

--- a/cncnet-api/app/Models/QmLadderRules.php
+++ b/cncnet-api/app/Models/QmLadderRules.php
@@ -24,7 +24,7 @@ class QmLadderRules extends Model
         'allowed_sides', 'bail_time', 'bail_fps', 'tier2_rating', 'rating_per_second',
         'max_points_difference', 'points_per_second', 'use_elo_points', 'wol_k',
         'upset_k', 'upset_k_loser_multiplier', 'fixed_points', 'no_negative_points',
-        'show_map_preview', 'reduce_map_repeats', 'use_ranked_map_picker'
+        'show_map_preview', 'reduce_map_repeats', 'use_ranked_map_picker', 'enable_replays'
     ];
 
     public static function newDefault($ladderId)
@@ -50,6 +50,8 @@ class QmLadderRules extends Model
         $rules->fixed_points      = 12;
         $rules->no_negative_points = true;
         $rules->show_map_preview = true;
+        // Replays stay off until a ladder opts in - only RA2/YR supports them.
+        $rules->enable_replays = false;
         $rules->use_ranked_map_picker = false;
         $rules->reduce_map_repeats = 0; //number of recent maps to exclude from next played game
 

--- a/cncnet-api/config/replays.php
+++ b/cncnet-api/config/replays.php
@@ -1,0 +1,63 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Maximum size of a single replay upload, in megabytes
+    |--------------------------------------------------------------------------
+    |
+    | Uploads larger than this are rejected. The Quick Match client applies the
+    | same limit before uploading, so exceeding it here means a malformed or
+    | tampered file.
+    |
+    */
+
+    'max_upload_mb' => env('REPLAY_MAX_UPLOAD_MB', 20),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Total replay storage budget, in megabytes
+    |--------------------------------------------------------------------------
+    |
+    | Deliberately a size budget rather than a file count, since replay sizes
+    | vary a lot with match length. Once stored replays exceed this, the oldest
+    | are deleted until the total is back under budget.
+    |
+    */
+
+    'max_total_mb' => env('REPLAY_MAX_TOTAL_MB', 2000),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Storage disk
+    |--------------------------------------------------------------------------
+    |
+    | Must be a private disk. Replays are served through an authorised
+    | controller route, never as directly reachable files.
+    |
+    */
+
+    'disk' => env('REPLAY_DISK', 'local'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Directory within the disk
+    |--------------------------------------------------------------------------
+    */
+
+    'directory' => 'replays',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Restrict downloads to staff
+    |--------------------------------------------------------------------------
+    |
+    | True during the beta so only staff can pull replays. Set to false to open
+    | downloads up to any authenticated user once testing is finished.
+    |
+    */
+
+    'staff_only_downloads' => env('REPLAY_STAFF_ONLY_DOWNLOADS', true),
+
+];

--- a/cncnet-api/database/factories/QmLadderRulesFactory.php
+++ b/cncnet-api/database/factories/QmLadderRulesFactory.php
@@ -35,6 +35,7 @@ class QmLadderRulesFactory extends Factory
             'fixed_points' => 12,
             'no_negative_points' => 1,
             'show_map_preview' => 1,
+            'enable_replays' => 0,
             'reduce_map_repeats' => 5,
             'use_ranked_map_picker' => 0,
             'use_elo_map_picker' => 0

--- a/cncnet-api/database/migrations/2026_07_26_000001_add_enable_replays_to_qm_ladder_rules.php
+++ b/cncnet-api/database/migrations/2026_07_26_000001_add_enable_replays_to_qm_ladder_rules.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Controls whether the Quick Match client records and uploads replays for a ladder.
+     *
+     * Defaults to false so replays stay off everywhere until a ladder explicitly opts in. This
+     * doubles as the kill switch: turning it off makes the client fall back to the stock spawner
+     * on the next match, with no client update required.
+     */
+    public function up(): void
+    {
+        Schema::table('qm_ladder_rules', function (Blueprint $table)
+        {
+            $table->boolean('enable_replays')->default(false)->after('show_map_preview');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('qm_ladder_rules', function (Blueprint $table)
+        {
+            $table->dropColumn('enable_replays');
+        });
+    }
+};

--- a/cncnet-api/database/migrations/2026_07_26_000002_create_game_replays_table.php
+++ b/cncnet-api/database/migrations/2026_07_26_000002_create_game_replays_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Replays recorded by the Quick Match spawner, one file per player per game.
+     *
+     * Each player's file differs - the replay stores that player's viewport and unit selection -
+     * so a game has as many replays as it had participants.
+     */
+    public function up(): void
+    {
+        Schema::create('game_replays', function (Blueprint $table)
+        {
+            $table->increments('id');
+            $table->integer('game_id')->unsigned();
+            $table->integer('player_id')->unsigned();
+            $table->integer('user_id')->unsigned();
+
+            // Path relative to the replay disk root. Randomised, not derived from the game or
+            // player, so the files cannot be enumerated if the storage root is ever exposed.
+            $table->string('filename');
+            $table->unsignedBigInteger('file_size');
+
+            $table->timestamps();
+
+            // One replay per player per game; a re-upload replaces the existing row.
+            $table->unique(['game_id', 'player_id']);
+
+            // Total-size accounting evicts oldest-first, and the game page looks replays up by game.
+            $table->index('created_at');
+            $table->index('game_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('game_replays');
+    }
+};

--- a/cncnet-api/database/schema/mariadb-schema.sql
+++ b/cncnet-api/database/schema/mariadb-schema.sql
@@ -795,7 +795,7 @@ CREATE TABLE `player_game_reports` (
   PRIMARY KEY (`id`),
   KEY `player_game_reports_player_id_index` (`player_id`),
   KEY `player_game_reports_game_report_id_index` (`game_report_id`),
-  KEY `player_game_reports_clan_id_index` (`clan_id`)
+  KEY `player_game_reports_clan_id_index` (`clan_id`),
   KEY `player_game_reports_created_at_index` (`created_at`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/cncnet-api/database/seeders/QmReplayTestSeeder.php
+++ b/cncnet-api/database/seeders/QmReplayTestSeeder.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Ladder;
+use App\Models\LadderHistory;
+use App\Models\Map;
+use App\Models\MapPool;
+use App\Models\Player;
+use App\Models\PlayerActiveHandle;
+use App\Models\QmLadderRules;
+use App\Models\QmMap;
+use App\Models\Side;
+use App\Models\User;
+use App\Models\UserSettings;
+use Carbon\Carbon;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+
+/**
+ * Sets up a local-only YR ladder with replays enabled, so the Quick Match replay flow can be
+ * exercised end to end without touching production.
+ *
+ * The maps are referenced by the SHA1 of real .map files already present in the game's
+ * "Maps/Yuri's Revenge" folder. The Quick Match client matches maps by hashing local files, so
+ * using real hashes means it finds them immediately instead of trying to download them from
+ * ladder.cncnet.org.
+ *
+ * Idempotent - safe to run repeatedly.
+ *
+ *   docker exec dev_cncnet_ladder_app php artisan db:seed --class=QmReplayTestSeeder
+ */
+class QmReplayTestSeeder extends Seeder
+{
+    // Must match a folder under resources/images/games/, otherwise the ladder listing page fails
+    // to resolve its logo through the Vite manifest and 500s.
+    private const LADDER_ABBREVIATION = 'yr';
+    private const TEST_PASSWORD = 'qmtest1234';
+
+    /**
+     * SHA1 of real map files shipped in the game folder. If these are ever regenerated, run
+     * `sha1sum` against "Maps/Yuri's Revenge/<file>" and update them here.
+     */
+    private const MAPS = [
+        ['hash' => '642bb8c8f8d6a15879d3afe276a54e4e4881b717', 'name' => 'Arctic Circle', 'file' => '2_arctic_circle.map'],
+        ['hash' => '44d1ac0d28d3c9c0be36b14516aa61c54e97fcf7', 'name' => 'Cold War',      'file' => '2_cold_war.map'],
+        ['hash' => 'aee78cb0db9e784d21bc5cfc07c4f144ec54f5b9', 'name' => 'Blockade',      'file' => '2_blockade.map'],
+    ];
+
+    public function run(): void
+    {
+        $ladder = Ladder::updateOrCreate(
+            ['abbreviation' => self::LADDER_ABBREVIATION],
+            [
+                'name'                  => 'QM Replay Test',
+                'game'                  => 'yr',
+                'clans_allowed'         => false,
+                'private'               => false,
+                'order'                 => 99,
+                'ladder_type'           => '1vs1',
+                'game_object_schema_id' => 1,
+            ]
+        );
+
+        $this->command->info("Ladder #{$ladder->id} ({$ladder->abbreviation})");
+
+        // Ladder history for the current month - this is what the /ladder/<short>/<abbrev> URLs use.
+        $now = Carbon::now();
+        $history = LadderHistory::updateOrCreate(
+            [
+                'ladder_id' => $ladder->id,
+                'short'     => $now->month . '-' . $now->year,
+            ],
+            [
+                'starts' => $now->copy()->startOfMonth(),
+                'ends'   => $now->copy()->endOfMonth(),
+            ]
+        );
+
+        $this->command->info("History #{$history->id} ({$history->short})");
+
+        foreach (['Allied' => 0, 'Soviet' => 1, 'Yuri' => 2] as $name => $localId)
+        {
+            Side::updateOrCreate(
+                ['ladder_id' => $ladder->id, 'local_id' => $localId],
+                ['name' => $name]
+            );
+        }
+
+        // -1 is "random side".
+        $allowedSides = '-1,0,1,2';
+
+        // The point of the whole exercise: replays on for this ladder only.
+        $rules = QmLadderRules::updateOrCreate(
+            ['ladder_id' => $ladder->id],
+            [
+                'player_count'             => 2,
+                'map_vetoes'               => 1,
+                'max_difference'           => 1000,
+                'all_sides'                => $allowedSides,
+                'allowed_sides'            => $allowedSides,
+                'bail_time'                => 30,
+                'bail_fps'                 => 30,
+                'tier2_rating'             => 0,
+                'rating_per_second'        => 0.75,
+                'max_points_difference'    => 1000,
+                'points_per_second'        => 0.5,
+                'use_elo_points'           => true,
+                'wol_k'                    => 64,
+                'upset_k'                  => 20,
+                'upset_k_loser_multiplier' => 0.25,
+                'fixed_points'             => 12,
+                'no_negative_points'       => true,
+                'show_map_preview'         => true,
+                'reduce_map_repeats'       => 0,
+                'use_ranked_map_picker'    => false,
+                'enable_replays'           => true,
+            ]
+        );
+
+        $this->command->info("Rules #{$rules->id} enable_replays=" . ($rules->enable_replays ? 'YES' : 'no'));
+
+        $mapPool = MapPool::updateOrCreate(
+            ['ladder_id' => $ladder->id, 'name' => 'QM Replay Test Pool'],
+            []
+        );
+
+        $ladder->update(['map_pool_id' => $mapPool->id]);
+
+        foreach (self::MAPS as $index => $mapData)
+        {
+            $map = Map::updateOrCreate(
+                ['hash' => $mapData['hash'], 'ladder_id' => $ladder->id],
+                [
+                    'name'        => $mapData['name'],
+                    'spawn_count' => 2,
+                    'image_path'  => '',
+                    'image_hash'  => '',
+                    'filename'    => $mapData['file'],
+                    'is_active'   => 1,
+                ]
+            );
+
+            QmMap::updateOrCreate(
+                ['ladder_id' => $ladder->id, 'map_id' => $map->id, 'map_pool_id' => $mapPool->id],
+                [
+                    'description'       => $mapData['name'],
+                    'admin_description' => $mapData['name'],
+                    'bit_idx'           => $index,
+                    'valid'             => 1,
+                    'spawn_order'       => '0,0',
+                    'team1_spawn_order' => '',
+                    'team2_spawn_order' => '',
+                    'allowed_sides'     => $allowedSides,
+                    'rejectable'        => 1,
+                    'default_reject'    => 0,
+                    'random_spawns'     => 0,
+                    'map_tier'          => 1,
+                    'weight'            => 1,
+                ]
+            );
+
+            $this->command->info("  Map {$mapData['name']} ({$mapData['file']})");
+        }
+
+        // Two accounts so a real 1v1 can be played across two machines. Both are given the God
+        // group so the staff-only replay download buttons are visible without extra setup.
+        foreach (['qmtest1', 'qmtest2'] as $username)
+        {
+            $user = User::updateOrCreate(
+                ['email' => $username . '@example.test'],
+                [
+                    'name'           => $username,
+                    'password'       => Hash::make(self::TEST_PASSWORD),
+                    'group'          => 'God',
+                    'email_verified' => 1,
+                    'alias'          => '',
+                    'chat_allowed'   => 1,
+                ]
+            );
+
+            UserSettings::updateOrCreate(
+                ['user_id' => $user->id],
+                [
+                    'match_ai'          => 0,
+                    'match_any_map'     => 1,
+                    'allow_observers'   => 1,
+                    'skip_score_screen' => 0,
+                ]
+            );
+
+            $player = Player::updateOrCreate(
+                ['username' => $username, 'ladder_id' => $ladder->id],
+                ['user_id' => $user->id, 'card_id' => 0, 'is_bot' => 0]
+            );
+
+            // The client lists usernames from player_active_handles, not from players directly,
+            // and only counts handles created within the current month. Without this the account
+            // endpoint returns an empty list and the client has nothing to queue with.
+            PlayerActiveHandle::updateOrCreate(
+                ['user_id' => $user->id, 'player_id' => $player->id, 'ladder_id' => $ladder->id],
+                ['created_at' => Carbon::now()]
+            );
+
+            $this->command->info("  User {$username} / " . self::TEST_PASSWORD . " (group God)");
+        }
+
+        $this->command->info('');
+        $this->command->info('Seed complete. Point the Quick Match client at this API and log in as qmtest1 / qmtest2.');
+    }
+}

--- a/cncnet-api/resources/views/admin/ladder-setup.blade.php
+++ b/cncnet-api/resources/views/admin/ladder-setup.blade.php
@@ -414,6 +414,19 @@
                                                     </select>
                                                 </div>
 
+                                                <div class="form-group">
+                                                    <label for="enable_replays">Enable Replays
+                                                        <span class="material-symbols-outlined" data-bs-toggle="tooltip" title="Records a replay per player and uploads it after the match. Only supported on RA2/YR ladders. Turning this off makes the Quick Match client fall back to the standard spawner on the next match, with no client update needed." style="font-size: 16px; cursor: help; color: #999;">help</span>
+                                                    </label>
+                                                    <select id="enable_replays" name="enable_replays" class="form-control">
+                                                        <option value="1" @if ($rule->enable_replays) selected @endif>
+                                                            Yes
+                                                        </option>
+                                                        <option value="0" @if (!$rule->enable_replays) selected @endif>No
+                                                        </option>
+                                                    </select>
+                                                </div>
+
                                                 <hr>
                                                 <p style="color: #fff">Point System</p>
 

--- a/cncnet-api/resources/views/ladders/clan-game-detail.blade.php
+++ b/cncnet-api/resources/views/ladders/clan-game-detail.blade.php
@@ -108,6 +108,8 @@ $pageTitle = 'Viewing Game - ';
                 @include('ladders.game._admin-game-tools')
             </div>
         </div>
+
+        @include('ladders.game._game-replays')
     @endif
 
     <section class="game-detail clan-detail">

--- a/cncnet-api/resources/views/ladders/game-detail.blade.php
+++ b/cncnet-api/resources/views/ladders/game-detail.blade.php
@@ -116,6 +116,8 @@ else {
                 @include('ladders.game._admin-game-tools')
             </div>
         </div>
+
+        @include('ladders.game._game-replays')
     @endif
 
     <section class="game-detail">

--- a/cncnet-api/resources/views/ladders/game/_game-replays.blade.php
+++ b/cncnet-api/resources/views/ladders/game/_game-replays.blade.php
@@ -1,0 +1,33 @@
+{{--
+    Per-player replay downloads.
+
+    Every participant has their own file: the replay stores that player's viewport and unit
+    selection, so each one plays back from that player's point of view.
+
+    Access is staff-only during the beta - see config/replays.php ('staff_only_downloads') and
+    ReplayController, which enforces it on the download route itself. Hiding the buttons here is
+    presentation only, not the access control.
+--}}
+@php
+    $replays = collect($playerGameReports)
+        ->filter(fn($pgr) => $pgr->playerReplay !== null)
+        ->sortBy(fn($pgr) => $pgr->player->username);
+@endphp
+
+@if ($replays->isNotEmpty())
+    <div class="container mt-3 mb-5">
+        <h5>Replays</h5>
+        <p class="text-muted" style="font-size: 0.9em;">
+            One file per player, each recorded from that player's point of view. Visible to staff only.
+        </p>
+
+        @foreach ($replays as $pgr)
+            @php $replay = $pgr->playerReplay; @endphp
+            <a class="btn btn-outline-secondary mb-2 me-2"
+               href="{{ route('replay.download', $replay->id) }}"
+               title="Uploaded {{ $replay->created_at }} &middot; {{ number_format($replay->file_size / 1024, 0) }} KB">
+                Download replay &ndash; {{ $pgr->player->username }}
+            </a>
+        @endforeach
+    </div>
+@endif

--- a/cncnet-api/routes/api.php
+++ b/cncnet-api/routes/api.php
@@ -53,6 +53,9 @@ Route::group(['prefix' => 'v1'], function ()
         Route::post('/result/ladder/{ladderId}/game/{gameId}/player/{playerId}/pings/{pingsSent}/{pingsReceived}', [\App\Http\Controllers\ApiLadderController::class, 'newPostLadder']);
         Route::post('/result/video-clip', [\App\Http\Controllers\ApiLadderController::class, 'saveVideoClip']);
 
+        // Replay Endpoints
+        Route::post('/replay/ladder/{ladderId}/game/{gameId}/player/{playerId}', [\App\Http\Controllers\ApiReplayController::class, 'uploadReplay']);
+
         // General Endpoints
         Route::get('/ping', [\App\Http\Controllers\ApiLadderController::class, 'pingLadder']);
 

--- a/cncnet-api/routes/web.php
+++ b/cncnet-api/routes/web.php
@@ -25,6 +25,13 @@ Route::get('/news/{slug}', [\App\Http\Controllers\NewsController::class, 'getNew
 // Route::get("/stats", "SiteController@getStats");
 Route::get('/canceledMatches/{ladderAbbreviation}', [\App\Http\Controllers\LadderController::class, 'getCanceledMatches']);
 
+# Replay downloads. Deliberately outside the 'cache.public' ladder group below - these responses
+# are permission-dependent and must never be served from a shared cache.
+Route::group(['prefix' => 'replay', 'middleware' => 'auth'], function ()
+{
+    Route::get('/{replayId}', [\App\Http\Controllers\ReplayController::class, 'download'])->name('replay.download');
+});
+
 # 1vs1 Player Ladders
 Route::group(['prefix' => 'ladder/', 'middleware' => ['cache.public']], function ()
 {

--- a/cncnet-api/tests/Unit/Spawn/SpawnIniTest.php
+++ b/cncnet-api/tests/Unit/Spawn/SpawnIniTest.php
@@ -58,6 +58,47 @@ class SpawnIniTest extends TestCase
         $this->assertNotNull($spawnStruct['spawn']['Settings']['IsSpectator']);
 
         $this->assertEquals($this->ladder->qmLadderRules->show_map_preview, $spawnStruct['client']['show_map_preview']);
+        $this->assertEquals((bool) $this->ladder->qmLadderRules->enable_replays, $spawnStruct['client']['enable_replays']);
+    }
+
+    /**
+     * The client keys off this flag to decide whether to record a replay and which spawner DLL to
+     * inject, so it has to be present and false unless a ladder has explicitly opted in.
+     */
+    public function test_enable_replays_defaults_off(): void
+    {
+        $p1 = $this->makePlayerForLadder('test1', $this->ladder, $this->makeUser('test1'));
+        $qmMatch = $this->makeQmMatch($this->ladder, $this->ladder->mapPool->maps->first());
+        $qmMatchPlayer = $this->makeQmMatchPlayer($p1, $this->ladder, $qmMatch, ['color' => 0, 'actual_side' => 1, 'location' => 0]);
+
+        $spawnStruct = QuickMatchSpawnService::createSpawnStruct(
+            $qmMatch,
+            $qmMatchPlayer,
+            $this->ladder,
+            $this->ladder->qmLadderRules
+        );
+
+        $this->assertArrayHasKey('enable_replays', $spawnStruct['client']);
+        $this->assertFalse($spawnStruct['client']['enable_replays']);
+    }
+
+    public function test_enable_replays_is_passed_through_when_on(): void
+    {
+        $this->ladder->qmLadderRules->enable_replays = true;
+        $this->ladder->qmLadderRules->save();
+
+        $p1 = $this->makePlayerForLadder('test1', $this->ladder, $this->makeUser('test1'));
+        $qmMatch = $this->makeQmMatch($this->ladder, $this->ladder->mapPool->maps->first());
+        $qmMatchPlayer = $this->makeQmMatchPlayer($p1, $this->ladder, $qmMatch, ['color' => 0, 'actual_side' => 1, 'location' => 0]);
+
+        $spawnStruct = QuickMatchSpawnService::createSpawnStruct(
+            $qmMatch,
+            $qmMatchPlayer,
+            $this->ladder,
+            $this->ladder->qmLadderRules->fresh()
+        );
+
+        $this->assertTrue($spawnStruct['client']['enable_replays']);
     }
 
     public function test_append_others_2(): void {


### PR DESCRIPTION
Adds endpoint for replay uploads and downloads. 
Download button when viewing a game through the website.
Downloads are currently for staff only.


<img width="1478" height="877" alt="image" src="https://github.com/user-attachments/assets/d872d973-bcff-49f1-87fa-a8aa9aa30158" />
